### PR TITLE
Fix registry behavior for cd with no arguments.

### DIFF
--- a/src/main/scala/org/labrad/registry/Registry.scala
+++ b/src/main/scala/org/labrad/registry/Registry.scala
@@ -86,7 +86,10 @@ extends ServerActor with Logging {
     @Setting(id=10,
              name="cd",
              doc="Change the current directory")
-    def changeDir(dir: Either[String, Seq[String]] = Left(""), create: Boolean = false): Seq[String] = {
+    def changeDir(): Seq[String] = {
+      store.pathTo(curDir)
+    }
+    def changeDir(dir: Either[String, Seq[String]], create: Boolean = false): Seq[String] = {
       val dirs = dir match {
         case Left(dir) => Seq(dir)
         case Right(dirs) => dirs

--- a/src/test/scala/org/labrad/RegistryTest.scala
+++ b/src/test/scala/org/labrad/RegistryTest.scala
@@ -59,6 +59,16 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
     }
   }
 
+  test("registry cd with no arguments stays in same directory") {
+    withManager { (host, port, password) =>
+      withClient(host, port, password) { c =>
+        await(c.send("Registry", "cd" -> Cluster(Arr(Str("test"), Str("a")), Bool(true))))
+        val result = await(c.send("Registry", "cd" -> Data.NONE))(0)
+        assert(result.get[Seq[String]] == Seq("", "test", "a"))
+      }
+    }
+  }
+
   test("registry sends message when key is created") {
     withManager { (host, port, password) =>
       withClient(host, port, password) { c =>


### PR DESCRIPTION
Previously the registry would cd into the root directory when called with no arguments. We change that to simply stay in the current directory, as the delphi registry does.

Fixes #6
