### PR TITLE
Improve builder to allow not specifying type in advance.

### DIFF
--- a/src/main/scala/org/labrad/data/DataBuilder.scala
+++ b/src/main/scala/org/labrad/data/DataBuilder.scala
@@ -5,81 +5,353 @@ import java.nio.ByteOrder
 import java.nio.ByteOrder._
 import java.nio.charset.StandardCharsets.UTF_8
 import org.labrad.types._
+import scala.collection.mutable
 
 object DataBuilder {
   def apply(tag: String): DataBuilder = apply(Type(tag))
-  def apply(t: Type)(implicit bo: ByteOrder = BIG_ENDIAN): DataBuilder = new DataBuilder(t)
+  def apply(t: Type = null)(implicit bo: ByteOrder = BIG_ENDIAN): DataBuilder = new DataBuilder(Option(t))
 }
 
-class DataBuilder(t: Type)(implicit byteOrder: ByteOrder = BIG_ENDIAN) { self =>
+class DataBuilder(tOpt: Option[Type] = None)(implicit byteOrder: ByteOrder = BIG_ENDIAN) { self =>
 
   private val buf = Unpooled.buffer().order(byteOrder)
+  private var state: State = Start(tOpt).call()
 
-  private var state: State = Consume(t, caller = Done).call()
+  def none(): this.type = { state = state.none(); this }
+  def bool(x: Boolean): this.type = { state = state.bool(x); this }
+  def int(x: Int): this.type = { state = state.int(x); this }
+  def uint(x: Long): this.type = { state = state.uint(x); this }
+  def bytes(x: Array[Byte]): this.type = { state = state.bytes(x); this }
+  def string(s: String): this.type = { state = state.string(s); this }
+  def time(seconds: Long, fraction: Long): this.type = { state = state.time(seconds, fraction); this }
+  def value(x: Double, unit: String = ""): this.type = { state = state.value(x, unit); this }
+  def complex(re: Double, im: Double, unit: String = ""): this.type = { state = state.complex(re, im, unit); this }
 
-  override def toString: String = {
-    s"DataBuilder($t, state = $state, bytes = ${buf.readableBytes})"
+  def array(size: Int): this.type = array(Array(size))
+  def array(shape: Int*): this.type = array(shape.toArray)
+  def array(shape: Array[Int]): this.type = { state = state.array(shape); this }
+
+  def clusterStart(): this.type = { state = state.clusterStart(); this }
+  def clusterEnd(): this.type = { state = state.clusterEnd(); this }
+
+  def error(code: Int, message: String): this.type = { state = state.error(code, message); this }
+
+  /**
+   * Add arbitrary labrad data to this builder.
+   *
+   * This could fail if we are expecting data of a type that does not match.
+   * TODO: check first if this is going to work to avoid partial completion?
+   */
+  def add(data: Data): this.type = {
+    data.t match {
+      case TNone => none()
+      case TBool => bool(data.getBool)
+      case TInt => int(data.getInt)
+      case TUInt => uint(data.getUInt)
+      case TTime => time(data.getSeconds, data.getFraction)
+      case TStr => bytes(data.getBytes)
+      case TValue(unitOpt) => value(data.getValue, unitOpt.getOrElse(""))
+      case TComplex(unitOpt) => complex(data.getReal, data.getImag, unitOpt.getOrElse(""))
+      case _: TArr =>
+        array(data.arrayShape)
+        for (elem <- data.flatIterator) {
+          add(elem)
+        }
+      case _: TCluster =>
+        clusterStart()
+        for (elem <- data.clusterIterator) {
+          add(elem)
+        }
+        clusterEnd()
+      case _: TError =>
+        error(data.getErrorCode, data.getErrorMessage)
+        add(data.getErrorPayload)
+    }
+    this
   }
 
-  sealed trait State {
-    def caller: State
-    def call(): State
-    def resume(): State
+  /**
+   * Add an object for which we have a ToData type class.
+   *
+   * The ToData takes this builder and the value as arguments and calls the
+   * appropriate builder methods to add the value to this builder.
+   * TODO: check first if this is going to work to avoid partial completion?
+   */
+  def add[T](value: T)(implicit toData: ToData[T]): this.type = {
+    toData(this, value)
+    this
+  }
 
+  /**
+   * Get the resulting Data object. Requires that we are in the Done state.
+   */
+  def result(): Data = {
+    state match {
+      case Done(t) => new FlatData(t, buf.toByteArray, 0)
+      case _ => throw new IllegalStateException(s"more data expected. state=$state")
+    }
+  }
+
+  override def toString: String = {
+    s"DataBuilder(state = $state, bytes = ${buf.readableBytes})"
+  }
+
+  /**
+   * States keep track of what has been added to the builder so far and what we
+   * expect next, so that we can ensure that we produce valid labrad data.
+   *
+   * States are arranged in a linked list like the activation frames in a call
+   * stack, with the currently active state at the top and each state having a
+   * reference to its caller. Each state can be thought of as a function (or,
+   * more precisely, a coroutine) that consumes one chunk of data, possibly
+   * calling into other states to consume parts of the data. When a given state
+   * is done, it returns the type of data consumed (which may or may not be
+   * known in advance) and resumes its caller.
+   */
+  sealed trait State {
+    /**
+     * The state that called us, to which we will return.
+     */
+    def caller: State
+
+    /**
+     * Call into this state. States are reusable, but not reentrant,
+     * hence this may be called multiple time, but not concurrently.
+     */
+    def call(): State
+
+    /**
+     * Resume this state from another state that we called. This should
+     * not be called explicitly; instead use ret() to return to the caller.
+     */
+    def resume(t: Type): State
+
+    /**
+     * Return the given type to our calling state.
+     */
+    def ret(t: Type): State = caller.resume(t)
+
+    // These are the methods that can be invoked to advance the builder
+    // and update the state. By default they all raise IllegalStateException,
+    // but subclasses of State may override the methods that represent valid
+    // continuations from that particular state.
+    def none(): State = fail("add none")
+    def bool(x: Boolean): State = fail("add bool")
+    def int(x: Int): State = fail("add int")
+    def uint(x: Long): State = fail("add uint")
+    def bytes(x: Array[Byte]): State = fail("add bytes")
+    def string(s: String): State = fail("add string")
+    def time(seconds: Long, fraction: Long): State = fail("add time")
+    def value(x: Double, unit: String = ""): State = fail("add value")
+    def complex(re: Double, im: Double, unit: String = ""): State = fail("add complex")
+    def array(shape: Array[Int]): State = fail("add array")
+    def clusterStart(): State = fail("start cluster")
+    def clusterEnd(): State = fail("end cluster")
+    def error(code: Int, message: String): State = fail("add error")
+
+    private def fail(msg: String) = {
+      throw new IllegalStateException(s"cannot $msg in state $this")
+    }
+
+    /**
+     * Create a human-readable representation of this state.
+     *
+     * Ideally, this would be drawn "top-down" but the caller linkages point
+     * in the opposite direction. Hence, instead of rendering recursively, we
+     * traverse the linked list of states and call the `render` method on each
+     * one, passing in the rendered substate from its callee. State subclasses
+     * must implement `render`.
+     */
     override def toString: String = {
-      var s = render("Done")
-      var state = caller
-      while (state != Done) {
-        s = state.render(s)
+      var state = this
+      var s = render("")
+      while (state.caller != state) {
         state = state.caller
+        s = state.render(s)
       }
       s
     }
-    def render(subState: String): String = super.toString
+
+    /**
+     * Create a human-readable representation of this state, using the given
+     * rendered subState.
+     */
+    def render(subState: String): String
   }
 
-  case object Done extends State {
-    def caller: State = Done
-    def call(): State = ???
-    def resume(): State = Done
+  /**
+   * The top-level state. We call a consumer for the specified type if given
+   * or an unknown type if not given, and then move to Done when it returns.
+   */
+  case class Start(tOpt: Option[Type]) extends State {
+    def caller: State = this
+    def call(): State = tOpt match {
+      case None => ConsumeAny(caller = this).call()
+      case Some(t) => consume(t, caller = this).call()
+    }
+    def resume(t: Type): State = {
+      for (tExpected <- tOpt) {
+        require(t == tExpected, s"expected $tExpected but builder produced $t")
+      }
+      Done(t)
+    }
     override def render(subState: String): String = subState
   }
 
-  private def Consume(t: Type, caller: State): State = {
+  /**
+   * Final state when we are ready to build the result.
+   */
+  case class Done(t: Type) extends State {
+    def caller: State = this
+    def call(): State = ???
+    def resume(t: Type): State = ???
+    override def render(subState: String): String = s"Done($t)"
+  }
+
+  private def consume(t: Type, caller: State): State = {
     t match {
       case TArr(elem, depth) => ConsumeArray(elem, depth, caller)
       case TCluster(elems @ _*) => ConsumeCluster(elems, caller)
-      case TError(payload) => Consume(TCluster(TInt, TStr, payload), caller)
+      case TError(payload) => ConsumeError(payload, caller)
       case t => ConsumeOne(t, caller)
     }
   }
 
-  case class ConsumeOne(t: Type, caller: State) extends State {
-    def call(): State = {
-      if (t == TNone) caller.resume() else this
+  trait ConsumeSimple extends State {
+    protected def check(t: Type): Unit
+
+    override def none(): State = {
+      check(TNone)
+      ret(TNone)
     }
-    def resume(): State = ???
-    def gotValue(): State = caller.resume()
+    override def bool(x: Boolean): State = {
+      check(TBool)
+      buf.writeBoolean(x)
+      ret(TBool)
+    }
+    override def int(x: Int): State = {
+      check(TInt)
+      buf.writeInt(x)
+      ret(TInt)
+    }
+    override def uint(x: Long): State = {
+      check(TUInt)
+      buf.writeInt(x.toInt)
+      ret(TUInt)
+    }
+    override def bytes(x: Array[Byte]): State = {
+      check(TStr)
+      buf.writeLen { buf.writeBytes(x) }
+      ret(TStr)
+    }
+    override def string(s: String): State = {
+      check(TStr)
+      buf.writeLen { buf.writeUtf8String(s) }
+      ret(TStr)
+    }
+    override def time(seconds: Long, fraction: Long): State = {
+      check(TTime)
+      buf.writeLong(seconds)
+      buf.writeLong(fraction)
+      ret(TTime)
+    }
+    override def value(x: Double, unit: String = ""): State = {
+      val t = TValue(Some(unit))
+      check(t)
+      buf.writeDouble(x)
+      ret(t)
+    }
+    override def complex(re: Double, im: Double, unit: String = ""): State = {
+      val t = TComplex(Some(unit))
+      check(t)
+      buf.writeDouble(re)
+      buf.writeDouble(im)
+      ret(t)
+    }
+  }
+
+  case class ConsumeAny(caller: State) extends ConsumeSimple {
+    def call(): State = this
+    def resume(t: Type): State = ???
+
+    // accept any type
+    override protected def check(t: Type): Unit = {}
+
+    override def array(shape: Array[Int]): State = ConsumeArrayAny(shape, caller = caller).call()
+    override def clusterStart(): State = ConsumeClusterAny(caller = caller).call()
+    override def clusterEnd(): State = caller.clusterEnd()
+    override def error(code: Int, message: String): State = ConsumeErrorPayload(code, message, caller = caller).call()
+
+    override def render(subState: String): String = "<?>"
+  }
+
+  case class ConsumeOne(t: Type, caller: State) extends ConsumeSimple {
+    def call(): State = this
+    def resume(t: Type): State = ???
+
+    // accept only matching types
+    override protected def check(t: Type): Unit = {
+      require(t == this.t, s"cannot add $t. expecting ${this.t}")
+    }
+
     override def render(subState: String): String = s"<$t>"
   }
 
+  case class ConsumeClusterAny(caller: State) extends State {
+    private val consumer = ConsumeAny(caller = this)
+    private var i = 0
+    private var elems: mutable.Buffer[Type] = _
+
+    def call(): State = {
+      i = 0
+      elems = mutable.Buffer.empty[Type]
+      consumer.call()
+    }
+
+    def resume(t: Type): State = {
+      i += 1
+      elems += t
+      consumer.call()
+    }
+
+    override def clusterEnd(): State = {
+      ret(TCluster(elems: _*))
+    }
+
+    override def render(subState: String): String = {
+      val elemStrs = elems.map(_.toString).mkString
+      s"($elemStrs$subState...)"
+    }
+  }
+
   case class ConsumeCluster(elems: Seq[Type], caller: State) extends State {
-    private val consumers = elems.toArray.map(t => Consume(t, caller = this))
     private val size = elems.length
+    private val consumers = elems.toArray.map(t => consume(t, caller = this))
+    private val t = TCluster(elems: _*)
     private var i = 0
 
     def call(): State = {
       i = 0
-      consumers(i).call()
+      this
     }
 
-    def resume(): State = {
+    def resume(t: Type): State = {
       i += 1
       if (i < size) {
         consumers(i).call()
       } else {
-        caller.resume()
+        this
       }
+    }
+
+    override def clusterStart(): State = {
+      require(i == 0, s"cannot start cluster in state $this")
+      consumers(i).call()
+    }
+
+    override def clusterEnd(): State = {
+      require(i == size, s"cannot end cluster. still expecting ${size - i} elements")
+      ret(t)
     }
 
     override def render(subState: String): String = {
@@ -94,8 +366,48 @@ class DataBuilder(t: Type)(implicit byteOrder: ByteOrder = BIG_ENDIAN) { self =>
     }
   }
 
+  case class ConsumeArrayAny(shape: Array[Int], caller: State) extends State {
+
+    require(shape.length >= 1, s"expecting shape of length at least 1.")
+    require(shape.forall(_ >= 0), s"dimensions must be nonnegative, got ${shape.mkString(",")}")
+
+    private val depth = shape.length
+    private val size: Int = shape.product
+
+    private var i: Int = 0
+    private var elem: Type = null
+    private val anyConsumer = ConsumeAny(caller = this) // for first element
+    private var consumer: State = null // for later elements when type is known
+
+    def call(): State = {
+      for (dim <- shape) {
+        buf.writeInt(dim)
+      }
+      i = 0
+      anyConsumer.call()
+    }
+
+    def resume(t: Type): State = {
+      if (i == 0) {
+        elem = t
+        consumer = consume(elem, caller = this)
+      }
+      i += 1
+      if (i < size) {
+        consumer.call()
+      } else {
+        ret(TArr(elem, depth))
+      }
+    }
+
+    override def render(subState: String): String = {
+      val dStr = if (depth == 1) "" else depth.toString
+      s"*$dStr{$i/$size}$subState"
+    }
+  }
+
   case class ConsumeArray(elem: Type, depth: Int, caller: State) extends State {
-    private val consumer = Consume(elem, caller = this)
+    private val consumer = consume(elem, caller = this)
     private var shape: Array[Int] = null
     private var size: Int = 0
     private var i: Int = 0
@@ -106,16 +418,16 @@ class DataBuilder(t: Type)(implicit byteOrder: ByteOrder = BIG_ENDIAN) { self =>
       this
     }
 
-    def resume(): State = {
+    def resume(t: Type): State = {
       i += 1
       if (i < size) {
         consumer.call()
       } else {
-        caller.resume()
+        ret(TArr(elem, depth))
       }
     }
 
-    def gotShape(shape: Array[Int]): State = {
+    override def array(shape: Array[Int]): State = {
       require(shape.length == depth, s"expecting shape of depth $depth, got ${shape.length}")
       require(shape.forall(_ >= 0), s"dimensions must be nonnegative, got ${shape.mkString(",")}")
       this.shape = shape
@@ -131,58 +443,56 @@ class DataBuilder(t: Type)(implicit byteOrder: ByteOrder = BIG_ENDIAN) { self =>
       if (shape == null) {
         s"*$dStr<shape>$elem"
       } else {
-        s"*$dStr{$i}$subState"
+        s"*$dStr{$i/$size}$subState"
       }
     }
   }
 
-  private def nope(msg: String) = {
-    throw new IllegalStateException(msg)
-  }
+  case class ConsumeError(payload: Type, caller: State) extends State {
+    private val consumer = ConsumeOne(payload, caller = this)
+    private var awaitingError = true
 
-  private def addSimple(p: Pattern)(write: => Unit): this.type = {
-    state = state match {
-      case state: ConsumeOne if p.accepts(state.t) => write; state.gotValue()
-      case state: ConsumeOne => nope(s"cannot add $p. expecting ${state.t}")
-      case state: ConsumeArray => nope(s"cannot add $p. expecting array shape")
-      case state => nope(s"cannot add $t. unexpected state: $state")
+    def call(): State = {
+      awaitingError = true
+      this
     }
-    this
-  }
 
-  def addBool(x: Boolean): this.type = addSimple(TBool) { buf.writeBoolean(x) }
-  def addInt(x: Int): this.type = addSimple(TInt) { buf.writeInt(x) }
-  def addUInt(x: Long): this.type = addSimple(TUInt) { buf.writeInt(x.toInt) }
-  def addBytes(x: Array[Byte]): this.type = addSimple(TStr) { buf.writeInt(x.length); buf.writeBytes(x) }
-  def addString(s: String): this.type = addSimple(TStr) {
-    val bytes = s.getBytes(UTF_8)
-    buf.writeInt(bytes.length)
-    buf.writeBytes(bytes)
-  }
-  def addTime(seconds: Long, fraction: Long): this.type = addSimple(TTime) { buf.writeLong(seconds); buf.writeLong(fraction) }
-  def addValue(x: Double): this.type = addSimple(PValue(None)) { buf.writeDouble(x) }
-  def addComplex(re: Double, im: Double): this.type = {
-    addSimple(PComplex(None)) { buf.writeDouble(re); buf.writeDouble(im) }
-  }
-
-  def setSize(size: Int): this.type = this.setShape(Array(size))
-  def setShape(shape: Int*): this.type = this.setShape(shape.toArray)
-  def setShape(shape: Array[Int]): this.type = {
-    state = state match {
-      case state: ConsumeArray => state.gotShape(shape)
-      case state: ConsumeOne => nope(s"cannot set shape. expecting ${state.t}")
-      case state => nope(s"cannot add $t. unexpected state: $state")
+    def resume(t: Type): State = {
+      ret(TError(t))
     }
-    this
+
+    override def error(code: Int, message: String): State = {
+      buf.writeInt(code)
+      buf.writeLen { buf.writeUtf8String(message) }
+      awaitingError = false
+      consumer.call()
+    }
+
+    override def render(subState: String): String = {
+      if (awaitingError) {
+        s"<E>$payload"
+      } else {
+        s"E$subState"
+      }
+    }
   }
 
-  def build(): Data = {
-    state match {
-      case Done => new FlatData(t, buf.toByteArray, 0)
-      case state: ConsumeArray => nope("cannot build. expecting array shape")
-      case state: ConsumeOne => nope(s"cannot build. expecting ${state.t}")
-      case state => nope(s"cannot build. unexpected state: $state")
+  case class ConsumeErrorPayload(code: Int, message: String, caller: State) extends State {
+    private val consumer = ConsumeAny(caller = this)
+    private var i = 0
+
+    def call(): State = {
+      buf.writeInt(code)
+      buf.writeLen { buf.writeUtf8String(message) }
+      consumer.call()
+    }
+
+    def resume(t: Type): State = {
+      ret(TError(t))
+    }
+
+    override def render(subState: String): String = {
+      s"E$subState"
     }
   }
 }
-

--- a/src/main/scala/org/labrad/data/ToData.scala
+++ b/src/main/scala/org/labrad/data/ToData.scala
@@ -1,0 +1,141 @@
+package org.labrad.data
+
+import java.util.Date
+import org.labrad.types._
+
+trait ToData[T] {
+  def pat: Pattern
+  def apply(b: DataBuilder, value: T): Unit
+
+  def apply(value: T): Data = {
+    val b = DataBuilder()
+    apply(b, value)
+    b.result()
+  }
+}
+
+object ToData {
+  implicit val dataToData = new ToData[Data] {
+    def pat = PAny
+    def apply(b: DataBuilder, value: Data): Unit = b.add(value)
+    override def apply(value: Data): Data = value
+  }
+  implicit val boolToData = new ToData[Boolean] {
+    def pat = TBool
+    def apply(b: DataBuilder, value: Boolean): Unit = b.bool(value)
+  }
+  implicit val intToData = new ToData[Int] {
+    def pat = TInt
+    def apply(b: DataBuilder, value: Int): Unit = b.int(value)
+  }
+  implicit val uintToData = new ToData[Long] {
+    def pat = TUInt
+    def apply(b: DataBuilder, value: Long): Unit = b.uint(value)
+  }
+  implicit val stringToData = new ToData[String] {
+    def pat = TStr
+    def apply(b: DataBuilder, value: String): Unit = b.string(value)
+  }
+  implicit val dateToData = new ToData[Date] {
+    def pat = TTime
+    def apply(b: DataBuilder, value: Date): Unit = { val t = TimeStamp(value); b.time(t.seconds, t.fraction) }
+  }
+  implicit def valueToData = new ToData[Double] {
+    def pat = TValue(None)
+    def apply(b: DataBuilder, value: Double): Unit = b.value(value)
+  }
+  def valueToData(unit: String) = new ToData[Double] {
+    def pat = TValue(Some(unit))
+    def apply(b: DataBuilder, value: Double): Unit = b.value(value, unit)
+  }
+  implicit def complexToData = new ToData[Complex] {
+    def pat = TComplex(None)
+    def apply(b: DataBuilder, value: Complex): Unit = b.complex(value.real, value.imag)
+  }
+  def complexToData(unit: String) = new ToData[Complex] {
+    def pat = TComplex(Some(unit))
+    def apply(b: DataBuilder, value: Complex): Unit = b.complex(value.real, value.imag, unit)
+  }
+
+  implicit def eitherToData[A, B](implicit aToData: ToData[A], bToData: ToData[B]) = new ToData[Either[A, B]] {
+    def pat = PChoice(aToData.pat, bToData.pat)
+    def apply(b: DataBuilder, value: Either[A, B]): Unit = {
+      value match {
+        case Left(valueA) => b.add(valueA)
+        case Right(valueB) => b.add(valueB)
+      }
+    }
+  }
+
+  implicit def tuple2ToData[T1, T2](implicit s1: ToData[T1], s2: ToData[T2]) = new ToData[(T1, T2)] {
+    def pat = PCluster(s1.pat, s2.pat)
+    def apply(b: DataBuilder, value: (T1, T2)): Unit = {
+      value match {
+        case (v1, v2) => b.clusterStart().add(v1).add(v2).clusterEnd()
+      }
+    }
+  }
+
+  implicit def tuple3ToData[T1, T2, T3](implicit s1: ToData[T1], s2: ToData[T2], s3: ToData[T3]) = new ToData[(T1, T2, T3)] {
+    def pat = PCluster(s1.pat, s2.pat, s3.pat)
+    def apply(b: DataBuilder, value: (T1, T2, T3)): Unit = {
+      value match {
+        case (v1, v2, v3) => b.clusterStart().add(v1).add(v2).add(v3).clusterEnd()
+      }
+    }
+  }
+
+  implicit def tuple4ToData[T1, T2, T3, T4](implicit s1: ToData[T1], s2: ToData[T2], s3: ToData[T3], s4: ToData[T4]) = new ToData[(T1, T2, T3, T4)] {
+    def pat = PCluster(s1.pat, s2.pat, s3.pat, s4.pat)
+    def apply(b: DataBuilder, value: (T1, T2, T3, T4)): Unit = {
+      value match {
+        case (v1, v2, v3, v4) => b.clusterStart().add(v1).add(v2).add(v3).add(v4).clusterEnd()
+      }
+    }
+  }
+
+  implicit def tuple5ToData[T1, T2, T3, T4, T5](implicit s1: ToData[T1], s2: ToData[T2], s3: ToData[T3], s4: ToData[T4], s5: ToData[T5]) = new ToData[(T1, T2, T3, T4, T5)] {
+    def pat = PCluster(s1.pat, s2.pat, s3.pat, s4.pat, s5.pat)
+    def apply(b: DataBuilder, value: (T1, T2, T3, T4, T5)): Unit = {
+      value match {
+        case (v1, v2, v3, v4, v5) => b.clusterStart().add(v1).add(v2).add(v3).add(v4).add(v5).clusterEnd()
+      }
+    }
+  }
+
+  implicit def tuple6ToData[T1, T2, T3, T4, T5, T6](implicit s1: ToData[T1], s2: ToData[T2], s3: ToData[T3], s4: ToData[T4], s5: ToData[T5], s6: ToData[T6]) = new ToData[(T1, T2, T3, T4, T5, T6)] {
+    def pat = PCluster(s1.pat, s2.pat, s3.pat, s4.pat, s5.pat, s6.pat)
+    def apply(b: DataBuilder, value: (T1, T2, T3, T4, T5, T6)): Unit = {
+      value match {
+        case (v1, v2, v3, v4, v5, v6) => b.clusterStart().add(v1).add(v2).add(v3).add(v4).add(v5).add(v6).clusterEnd()
+      }
+    }
+  }
+
+  implicit def tuple7ToData[T1, T2, T3, T4, T5, T6, T7](implicit s1: ToData[T1], s2: ToData[T2], s3: ToData[T3], s4: ToData[T4], s5: ToData[T5], s6: ToData[T6], s7: ToData[T7]) = new ToData[(T1, T2, T3, T4, T5, T6, T7)] {
+    def pat = PCluster(s1.pat, s2.pat, s3.pat, s4.pat, s5.pat, s6.pat, s7.pat)
+    def apply(b: DataBuilder, value: (T1, T2, T3, T4, T5, T6, T7)): Unit = {
+      value match {
+        case (v1, v2, v3, v4, v5, v6, v7) => b.clusterStart().add(v1).add(v2).add(v3).add(v4).add(v5).add(v6).add(v7).clusterEnd()
+      }
+    }
+  }
+
+  implicit def tuple8ToData[T1, T2, T3, T4, T5, T6, T7, T8](implicit s1: ToData[T1], s2: ToData[T2], s3: ToData[T3], s4: ToData[T4], s5: ToData[T5], s6: ToData[T6], s7: ToData[T7], s8: ToData[T8]) = new ToData[(T1, T2, T3, T4, T5, T6, T7, T8)] {
+    def pat = PCluster(s1.pat, s2.pat, s3.pat, s4.pat, s5.pat, s6.pat, s7.pat, s8.pat)
+    def apply(b: DataBuilder, value: (T1, T2, T3, T4, T5, T6, T7, T8)): Unit = {
+      value match {
+        case (v1, v2, v3, v4, v5, v6, v7, v8) => b.clusterStart().add(v1).add(v2).add(v3).add(v4).add(v5).add(v6).add(v7).add(v8).clusterEnd()
+      }
+    }
+  }
+
+  implicit def tuple9ToData[T1, T2, T3, T4, T5, T6, T7, T8, T9](implicit s1: ToData[T1], s2: ToData[T2], s3: ToData[T3], s4: ToData[T4], s5: ToData[T5], s6: ToData[T6], s7: ToData[T7], s8: ToData[T8], s9: ToData[T9]) = new ToData[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] {
+    def pat = PCluster(s1.pat, s2.pat, s3.pat, s4.pat, s5.pat, s6.pat, s7.pat, s8.pat, s9.pat)
+    def apply(b: DataBuilder, value: (T1, T2, T3, T4, T5, T6, T7, T8, T9)): Unit = {
+      value match {
+        case (v1, v2, v3, v4, v5, v6, v7, v8, v9) => b.clusterStart().add(v1).add(v2).add(v3).add(v4).add(v5).add(v6).add(v7).add(v8).add(v9).clusterEnd()
+      }
+    }
+  }
+}

--- a/src/test/scala/org/labrad/data/DataBench.scala
+++ b/src/test/scala/org/labrad/data/DataBench.scala
@@ -21,15 +21,17 @@ object DataBench {
     val N = 512
 
     val data1 = {
-      val b = DataBuilder("*(ssis)")
-      b.setSize(N)
+      val b = DataBuilder()
+      b.array(N)
       for (_ <- 0 until N) {
-        b.addString("01:23:45:67:89:AB")
-        b.addString("01:23:45:67:89:AB")
-        b.addInt(128)
-        b.addBytes(Array.tabulate(128)(_.toByte))
+        b.clusterStart()
+           .string("01:23:45:67:89:AB")
+           .string("01:23:45:67:89:AB")
+           .int(128)
+           .bytes(Array.tabulate(128)(_.toByte))
+         .clusterEnd()
       }
-      b.build()
+      b.result()
     }
 
     val data2 = Arr(Seq.fill(N) { Cluster(Str("01:23:45:67:89:AB"), Str("01:23:45:67:89:AB"), Integer(128), Bytes(Array.tabulate(128)(_.toByte))) })

--- a/src/test/scala/org/labrad/data/DataBuilderTest.scala
+++ b/src/test/scala/org/labrad/data/DataBuilderTest.scala
@@ -1,0 +1,118 @@
+package org.labrad.data
+
+import java.nio.ByteOrder
+import java.util.{Date, Random}
+import org.labrad.types._
+import org.scalatest.FunSuite
+
+class DataBuilderTest extends FunSuite {
+  val rand = new Random
+
+  def testBothEndian(name: String)(func: ByteOrder => Unit) {
+    for (byteOrder <- List(ByteOrder.BIG_ENDIAN, ByteOrder.LITTLE_ENDIAN))
+      test(name + ":" + byteOrder) { func(byteOrder) }
+  }
+
+  testBothEndian("integer") { implicit bo: ByteOrder =>
+    for (n <- Seq(100, 0, 1, -1, Int.MaxValue, Int.MinValue)) {
+      val d1 = DataBuilder().int(n).result()
+      val d2 = DataBuilder("i").int(n).result()
+      assert(d1.t == TInt)
+      assert(d2.t == TInt)
+      assert(d1.getInt == n)
+      assert(d2.getInt == n)
+    }
+  }
+
+  testBothEndian("string") { implicit bo: ByteOrder =>
+    val s = "This is a test."
+    val d1 = DataBuilder().string(s).result()
+    val d2 = DataBuilder().string(s).result()
+    assert(d1.t == TStr)
+    assert(d2.t == TStr)
+    assert(d1.getString == s)
+    assert(d2.getString == s)
+  }
+
+  testBothEndian("date") { implicit bo: ByteOrder =>
+    for (count <- 0 until 100000) {
+      val date = new Date(rand.nextLong)
+      val timestamp = TimeStamp(date)
+      val d1 = DataBuilder().time(timestamp.seconds, timestamp.fraction).result()
+      val d2 = DataBuilder().time(timestamp.seconds, timestamp.fraction).result()
+      assert(d1.t == TTime)
+      assert(d2.t == TTime)
+      assert(d1.getTime.toDate == date)
+      assert(d2.getTime.toDate == date)
+    }
+  }
+
+  testBothEndian("string list") { implicit bo: ByteOrder =>
+    def check(b: DataBuilder): Unit = {
+      b.array(20)
+      for (count <- 0 until 20) {
+        b.string(s"This is string $count")
+      }
+      val d = b.result()
+      val it = d.flatIterator
+      for (count <- 0 until 20) {
+        assert(it.next.getString == s"This is string $count")
+      }
+    }
+    check(DataBuilder())
+    check(DataBuilder("*s"))
+  }
+
+  test("DataBuilder enforces that arrays are homogeneous") {
+    val b = DataBuilder()
+    b.array(2)
+    b.int(1)
+    intercept[Exception] { b.string("oops!") }
+  }
+
+  test("cluster fails to build if not wrong number of elements are provided") {
+    val b = DataBuilder("(ss)")
+    b.clusterStart()
+    intercept[Exception] { b.clusterEnd() }
+    b.string("a")
+    intercept[Exception] { b.clusterEnd() }
+    b.string("b")
+    intercept[Exception] { b.string("c") }
+    b.clusterEnd()
+    b.result()
+  }
+
+  test("array elem type inferred from first element") {
+    val b = DataBuilder()
+    b.array(2)
+     .clusterStart()
+       .string("a")
+       .int(1)
+     .clusterEnd()
+
+    // now the type is *(si) so we expect (si) for the next element
+    intercept[Exception] { b.int(1) }
+    b.clusterStart()
+    intercept[Exception] { b.clusterEnd() }
+    intercept[Exception] { b.int(1) }
+    b.string("b")
+    intercept[Exception] { b.clusterEnd() }
+    b.int(2)
+    intercept[Exception] { b.string("c") }
+    b.clusterEnd()
+    b.result()
+  }
+
+  test("multi-dimensional array accepts correct number of elements") {
+    val b = DataBuilder()
+    b.array(2, 3)
+     .int(11)
+     .int(12)
+     .int(13)
+     .int(21)
+     .int(22)
+     .int(23)
+    intercept[Exception] { b.int(31) }
+    b.result()
+  }
+}


### PR DESCRIPTION
This makes the `DataBuilder` class much more pleasant to use for constructing data recursively, because we do not need to traverse our recursive structure twice (once to find the full type and once to add it to the builder), which would have been necessary previously.

Also adds some tests for `DataBuilder` to verify that it is working and to illustrate its usage.

In addition, we add a `ToData` type class for converting scala types to labrad data by adding to a `DataBuilder`. I'm not sure about the name of this class; `Build[T]` might be better than `ToData[T]`. Note also that this is rather similar to the `Setter` type class, though I think this will be more useful and we might be able to get rid of `Setter` and convert everything to use this instead. The advantage is that it allows us to build up composite types without knowing the full combined type ahead of time, as discussed above.
