### PR TITLE
Use netty instead of blocking io in threads for client/server connections

### DIFF
--- a/src/main/scala/org/labrad/manager/Listener.scala
+++ b/src/main/scala/org/labrad/manager/Listener.scala
@@ -27,7 +27,7 @@ extends Logging {
      .childHandler(new ChannelInitializer[SocketChannel] {
          override def initChannel(ch: SocketChannel): Unit = {
            val p = ch.pipeline
-           p.addLast("packetCodec", new PacketCodec)
+           p.addLast("packetCodec", new PacketCodec())
            p.addLast("loginHandler", new LoginHandler(auth, hub, tracker, messager))
          }
      })

--- a/src/main/scala/org/labrad/protocol.scala
+++ b/src/main/scala/org/labrad/protocol.scala
@@ -13,11 +13,16 @@ import org.labrad.util.Logging
 
 
 /**
- * Decoder that reads incoming LabRAD packets on a netty channel
+ * Decoder that reads incoming LabRAD packets on a netty channel.
+ *
+ * If forceByteOrder is null, the byte order will be detected from the first incoming
+ * packet, suitable for use by the manager. For client or server connections
+ * which send before they receive, forceByteOrder should instead be set to the
+ * desired byte order for the connection.
  */
-class PacketCodec extends ByteToMessageCodec[Packet] with Logging {
+class PacketCodec(forceByteOrder: ByteOrder = null) extends ByteToMessageCodec[Packet] with Logging {
 
-  private var byteOrder: ByteOrder = null
+  private var byteOrder: ByteOrder = forceByteOrder
 
   protected override def decode(ctx: ChannelHandlerContext, in: ByteBuf, out: JList[AnyRef]): Unit = {
     // Wait until the full header is available


### PR DESCRIPTION
Previously the manager code used the netty library for asynchronous io, but client and server connections used blocking io in their own thread. By converting to netty, we should be able to more efficiently use the cpu for networking without as much context switching.
