### PR TITLE
Add support for TLS connections to labrad.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,9 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.2",
   "ch.qos.logback" % "logback-classic" % "1.0.6",
   "com.typesafe.play" %% "anorm" % "2.4.0-M2",
-  "org.xerial" % "sqlite-jdbc" % "3.8.7"
+  "org.xerial" % "sqlite-jdbc" % "3.8.7",
+  "org.bouncycastle" % "bcprov-jdk15on" % "1.52",
+  "org.bouncycastle" % "bcpkix-jdk15on" % "1.52"
 )
 
 // When running, connect std in and tell manager to stop on EOF (ctrl+D).

--- a/src/main/scala/io/netty/handler/ssl/util/SelfSignedCert.scala
+++ b/src/main/scala/io/netty/handler/ssl/util/SelfSignedCert.scala
@@ -1,0 +1,30 @@
+package io.netty.handler.ssl.util
+
+import java.io.File
+import java.security.{KeyPairGenerator, SecureRandom}
+
+
+/**
+ * A container for a self-signed certificate and its private key.
+ *
+ * We use netty's code for generating self-signed certificates, but specialized to always
+ * use their bouncy castle generator, which uses SHA256 to sign the cert, instead of SHA1
+ * as used by their jdk certificate generator.
+ *
+ * We put this in the io.netty.handler.ssl.util package so that we can access the package
+ * protected BouncyCastleSelfSignedCertGenerator class.
+ */
+case class SelfSignedCert(certificate: File, privateKey: File)
+
+
+object SelfSignedCert {
+  def apply(fqdn: String, bits: Int = 2048)(implicit random: SecureRandom = new SecureRandom): SelfSignedCert = {
+    val keyGen = KeyPairGenerator.getInstance("RSA")
+    keyGen.initialize(bits, random)
+    val keypair = keyGen.generateKeyPair()
+
+    val Array(cert, key) = BouncyCastleSelfSignedCertGenerator.generate(fqdn, keypair, random)
+
+    SelfSignedCert(new File(cert), new File(key))
+  }
+}

--- a/src/main/scala/org/labrad/Client.scala
+++ b/src/main/scala/org/labrad/Client.scala
@@ -1,16 +1,30 @@
 package org.labrad
 
+import java.io.File
 import org.labrad.data._
 
 class Client(
-  val name: String = "Scala Client",
-  val host: String = sys.env.getOrElse("LABRADHOST", ""),
-  val port: Int = sys.env.getOrElse("LABRADPORT", "7682").toInt,
-  val password: Array[Char] = sys.env.getOrElse("LABRADPASSWORD", "").toCharArray
+  val name: String = Client.defaults.name,
+  val host: String = Client.defaults.host,
+  val port: Int = Client.defaults.port,
+  val password: Array[Char] = Client.defaults.password,
+  val tls: TlsMode = Client.defaults.tls,
+  val tlsCerts: Map[String, File] = Map()
 ) extends Connection {
   protected def loginData = Cluster(UInt(Client.PROTOCOL_VERSION), Str(name))
 }
 
 object Client {
   val PROTOCOL_VERSION = 1L
+
+  object defaults {
+    def name: String = "Scala Client"
+    def host: String = sys.env.getOrElse("LABRADHOST", "localhost")
+    def password: Array[Char] = sys.env.getOrElse("LABRADPASSWORD", "").toCharArray
+    def port: Int = tls match {
+      case TlsMode.ON => sys.env.getOrElse("LABRAD_TLS_PORT", "7643").toInt
+      case _          => sys.env.getOrElse("LABRADPORT", "7682").toInt
+    }
+    def tls: TlsMode = sys.env.get("LABRAD_TLS").map(TlsMode.fromString).getOrElse(TlsMode.STARTTLS)
+  }
 }

--- a/src/main/scala/org/labrad/Connection.scala
+++ b/src/main/scala/org/labrad/Connection.scala
@@ -5,10 +5,12 @@ import io.netty.channel.{Channel, ChannelHandlerContext, ChannelOption, ChannelI
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioSocketChannel
-import java.io.IOException
-import java.nio.ByteOrder
-import java.nio.CharBuffer
+import io.netty.handler.ssl.{SslContext, SslContextBuilder}
+import java.io.{File, IOException}
+import java.net.{InetAddress, InetSocketAddress}
+import java.nio.{ByteOrder, CharBuffer}
 import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
 import java.security.MessageDigest
 import java.util.concurrent.{ExecutionException, Executors, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
@@ -17,14 +19,43 @@ import org.labrad.errors._
 import org.labrad.events.MessageListener
 import org.labrad.manager.Manager
 import org.labrad.util.{Counter, LookupProvider}
+import org.labrad.util.Futures._
+import org.labrad.util.Paths._
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 
+/**
+ * Modes of operation for securing client connections with TLS.
+ */
+sealed trait TlsMode
+
+object TlsMode {
+  case object OFF extends TlsMode
+  case object STARTTLS extends TlsMode
+  case object STARTTLS_FORCE extends TlsMode
+  case object ON extends TlsMode
+
+  def fromString(s: String): TlsMode = {
+    s.toLowerCase match {
+      case "on" => ON
+      case "off" => OFF
+      case "starttls" => STARTTLS
+      case "starttls-force" => STARTTLS_FORCE
+      case _ => sys.error(s"Invalid tls mode '$s'. Expected 'on', 'off', or 'starttls'.")
+    }
+  }
+}
+
+/**
+ * A client or server connection to the Labrad manager.
+ */
 trait Connection {
 
   val name: String
   val host: String
   val port: Int
+  val tls: TlsMode
+  val tlsCerts: Map[String, File]
   def password: Array[Char]
 
   var id: Long = _
@@ -64,6 +95,31 @@ trait Connection {
 
   private var channel: Channel = _
 
+  private def certsDirectory = sys.props("user.home") / ".labrad" / "client" / "certs"
+  private def certFile(hostname: String): File = certsDirectory / s"${hostname}.cert"
+
+  /**
+   * Create an SSL context for the given hostname.
+   *
+   * We look for trusted certificate files first in the tlsCerts map, then
+   * in the default location on disk. If no appropriate certificate is found
+   * in either of those locations, the resulting SSL context will instead use
+   * the system-default trust roots to validate the server certificate, which
+   * will only work if the server uses a certificate issued by a well-known
+   * certificate authority.
+   */
+  private def makeSslContext(hostname: String): SslContext = {
+    val sslContextBuilder = SslContextBuilder.forClient()
+    val file = tlsCerts.get(hostname) match {
+      case Some(file) => file
+      case None => certFile(hostname)
+    }
+    if (file.exists) {
+      sslContextBuilder.trustManager(file)
+    }
+    sslContextBuilder.build()
+  }
+
   def connect(): Unit = {
     val b = new Bootstrap()
     b.group(workerGroup)
@@ -71,25 +127,53 @@ trait Connection {
      .option[java.lang.Boolean](ChannelOption.TCP_NODELAY, true)
      .option[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, true)
      .handler(new ChannelInitializer[SocketChannel] {
-         override def initChannel(ch: SocketChannel): Unit = {
-           val p = ch.pipeline
-           p.addLast("packetCodec", new PacketCodec(forceByteOrder = ByteOrder.BIG_ENDIAN))
-           p.addLast("packetHandler", new SimpleChannelInboundHandler[Packet] {
-             override protected def channelRead0(ctx: ChannelHandlerContext, packet: Packet): Unit = {
-               handlePacket(packet)
-             }
-
-             override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
-               closeNoWait(cause)
-             }
-           })
-         }
+        override def initChannel(ch: SocketChannel): Unit = {
+          val p = ch.pipeline
+          if (tls == TlsMode.ON) {
+            p.addLast("sslContext", makeSslContext(host).newHandler(ch.alloc(), host, port))
+          }
+          p.addLast("packetCodec", new PacketCodec(forceByteOrder = ByteOrder.BIG_ENDIAN))
+          p.addLast("packetHandler", new SimpleChannelInboundHandler[Packet] {
+            override protected def channelRead0(ctx: ChannelHandlerContext, packet: Packet): Unit = {
+              handlePacket(packet)
+            }
+            override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+              closeNoWait(cause)
+            }
+            override def channelInactive(ctx: ChannelHandlerContext): Unit = {
+              closeNoWait(new Exception("channel closed"))
+            }
+          })
+        }
      })
 
     channel = b.connect(host, port).sync().channel
 
     connected = true
+
     try {
+      val isLocalConnection = (channel.remoteAddress, channel.localAddress) match {
+        case (remote: InetSocketAddress, local: InetSocketAddress) =>
+          remote.getAddress.isLoopbackAddress || remote.getAddress == local.getAddress
+
+        case _ => false
+      }
+
+      val useStartTls = tls match {
+        case TlsMode.STARTTLS_FORCE => true
+        case TlsMode.STARTTLS if !isLocalConnection => true
+        case _ => false
+      }
+
+      if (useStartTls) {
+        val startTls = Request(Manager.ID, records = Seq(Record(1, Cluster(Str("STARTTLS"), Str(host)))))
+        val Str(cert) = Await.result(send(startTls), 10.seconds)(0)
+
+        var handler = makeSslContext(host).newHandler(channel.alloc(), host, port)
+        channel.pipeline.addFirst("sslHandler", handler)
+        Await.result(handler.handshakeFuture.toScala, 10.seconds)
+      }
+
       doLogin(password)
     } catch {
       case e: Throwable => close(e); throw e

--- a/src/main/scala/org/labrad/ServerConnection.scala
+++ b/src/main/scala/org/labrad/ServerConnection.scala
@@ -1,15 +1,9 @@
 package org.labrad
 
+import java.io.File
 import org.labrad.data._
-import org.labrad.errors._
-import org.labrad.events._
-import org.labrad.util._
-import scala.collection._
-import scala.concurrent.{Await, Future, Promise}
-import scala.concurrent.duration._
-import scala.reflect.ClassTag
-import scala.reflect.runtime.currentMirror
-import scala.reflect.runtime.universe._
+import org.labrad.util.Logging
+import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 
@@ -19,6 +13,8 @@ class ServerConnection(
   val host: String,
   val port: Int,
   val password: Array[Char],
+  val tls: TlsMode = TlsMode.STARTTLS,
+  val tlsCerts: Map[String, File] = Map(),
   handler: Packet => Future[Packet]
 ) extends Connection with Logging {
 

--- a/src/main/scala/org/labrad/manager/Listener.scala
+++ b/src/main/scala/org/labrad/manager/Listener.scala
@@ -5,49 +5,126 @@ import io.netty.channel._
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
+import io.netty.handler.ssl.{SniHandler, SslContext}
+import io.netty.util.DomainNameMapping
 import org.labrad.PacketCodec
 import org.labrad.util._
 import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
 
 /**
- * listens for incoming labrad network connections
+ * Manager policies for securing incoming client/server connections with TLS.
  */
-class Listener(auth: AuthService, hub: Hub, tracker: StatsTracker, messager: Messager, port: Int)(implicit ec: ExecutionContext)
-extends Logging {
+sealed trait TlsPolicy
 
+object TlsPolicy {
+  /**
+   * Initial connection uses TLS.
+   */
+  case object ON extends TlsPolicy
+
+  /**
+   * No TLS; connection is unencrypted and attempts to upgrade with STARTTLS
+   * will be rejected. This is provided for testing and for compatibility with
+   * the old manager.
+   */
+  case object OFF extends TlsPolicy
+
+  /**
+   * Default STARTTLS behavior. Connection starts unencrypted and we use
+   * STARTTLS to upgrade later. STARTTLS is required for remote connections,
+   * but optional for connections from localhost.
+   */
+  case object STARTTLS extends TlsPolicy
+
+  /**
+   * STARTTLS is optional for all connections, including from remote hosts.
+   */
+  case object STARTTLS_OPT extends TlsPolicy
+
+  /**
+   * STARTTLS is required for all connection, including from localhost.
+   */
+  case object STARTTLS_FORCE extends TlsPolicy
+
+  def fromString(s: String): TlsPolicy = {
+    s.toLowerCase match {
+      case "on" => ON
+      case "off" => OFF
+      case "starttls" => STARTTLS
+      case "starttls-opt" => STARTTLS_OPT
+      case "starttls-force" => STARTTLS_FORCE
+      case _ => sys.error(s"Invalid tls mode '$s'. Expected 'on', 'off', or 'starttls'.")
+    }
+  }
+}
+
+/**
+ * Listens on one or more ports for incoming labrad network connections.
+ */
+class Listener(
+  auth: AuthService,
+  hub: Hub,
+  tracker: StatsTracker,
+  messager: Messager,
+  listeners: Seq[(Int, TlsPolicy)],
+  tlsHostConfig: TlsHostConfig
+)(implicit ec: ExecutionContext)
+extends Logging {
   val bossGroup = new NioEventLoopGroup(1)
   val workerGroup = new NioEventLoopGroup()
 
-  val serverChannel = try {
-    val b = new ServerBootstrap()
-    b.group(bossGroup, workerGroup)
-     .channel(classOf[NioServerSocketChannel])
-     .childOption[java.lang.Boolean](ChannelOption.TCP_NODELAY, true)
-     .childOption[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, true)
-     .childHandler(new ChannelInitializer[SocketChannel] {
+  def bootServer(port: Int, tlsPolicy: TlsPolicy): Channel = {
+    try {
+      val b = new ServerBootstrap()
+      b.group(bossGroup, workerGroup)
+       .channel(classOf[NioServerSocketChannel])
+       .childOption[java.lang.Boolean](ChannelOption.TCP_NODELAY, true)
+       .childOption[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, true)
+       .childHandler(new ChannelInitializer[SocketChannel] {
          override def initChannel(ch: SocketChannel): Unit = {
            val p = ch.pipeline
+           if (tlsPolicy == TlsPolicy.ON) {
+             p.addLast(new SniHandler(tlsHostConfig.sslCtxs))
+           }
            p.addLast("packetCodec", new PacketCodec())
-           p.addLast("loginHandler", new LoginHandler(auth, hub, tracker, messager))
+           p.addLast("loginHandler",
+             new LoginHandler(auth, hub, tracker, messager, tlsHostConfig, tlsPolicy))
          }
-     })
+       })
 
-    // Bind and start to accept incoming connections.
-    b.bind(port).sync().channel
-  } catch {
-    case e: Exception =>
-      workerGroup.shutdownGracefully()
-      bossGroup.shutdownGracefully()
-      throw e
+      // Bind and start to accept incoming connections.
+      val ch = b.bind(port).sync().channel
+      log.info(s"now accepting labrad connections: port=$port, tlsPolicy=$tlsPolicy")
+      ch
+    } catch {
+      case e: Exception =>
+        stop()
+        throw e
+    }
   }
 
-  log.info(s"now accepting labrad connections on port $port")
+  val listenerTrys = listeners.map { case (port, tlsPolicy) => Try(bootServer(port, tlsPolicy)) }
+  val channels = listenerTrys.collect { case Success(ch) => ch }
+  val failures = listenerTrys.collect { case Failure(e) => e }
+
+  // If any listeners failed to start, shutdown those that _did_ start and fail.
+  if (!failures.isEmpty) {
+    shutdown(channels)
+    throw new Exception(s"some listeners failed to start: ${failures.mkString(", ")}")
+  }
 
   def stop() {
     log.info("shutting down")
+    shutdown(channels)
+  }
+
+  private def shutdown(listeners: Seq[Channel]): Unit = {
     try {
-      serverChannel.close()
-      serverChannel.closeFuture.sync()
+      for (ch <- listeners) {
+        ch.close()
+        ch.closeFuture.sync()
+      }
     } finally {
       workerGroup.shutdownGracefully()
       bossGroup.shutdownGracefully()

--- a/src/main/scala/org/labrad/manager/LoginHandler.scala
+++ b/src/main/scala/org/labrad/manager/LoginHandler.scala
@@ -1,6 +1,12 @@
 package org.labrad.manager
 
 import io.netty.channel._
+import io.netty.handler.ssl.{SslContext, SslHandler}
+import io.netty.util.DomainNameMapping
+import java.io.{ByteArrayOutputStream, File, FileInputStream}
+import java.net.{InetAddress, InetSocketAddress}
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
 import org.labrad.ContextCodec
 import org.labrad.data._
 import org.labrad.errors._
@@ -10,8 +16,67 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Random
 
-class LoginHandler(auth: AuthService, hub: Hub, tracker: StatsTracker, messager: Messager)(implicit ec: ExecutionContext)
+/**
+ * Configuration of TLS cert/key pairs for one or more hostnames.
+ *
+ * This is used with SNI (Server Name Indication) to allow the manager to
+ * present the appropriate certificate to the client, based on the hostname
+ * to which the client is connecting. We also need this for STARTTLS, where
+ * the client sends the hostname along with the STARTTLS request so that we
+ * can pick the correct cert.
+ */
+case class TlsHostConfig(
+  certs: DomainNameMapping[String],
+  certFiles: DomainNameMapping[File],
+  sslCtxs: DomainNameMapping[SslContext]
+)
+
+object TlsHostConfig {
+  def apply(default: (File, SslContext), hosts: (String, (File, SslContext))*): TlsHostConfig = {
+    val (defaultCertFile, defaultSslCtx) = default
+    val certMapping = new DomainNameMapping[String](readFile(defaultCertFile))
+    val certFileMapping = new DomainNameMapping[File](defaultCertFile)
+    val ctxMapping = new DomainNameMapping[SslContext](defaultSslCtx)
+
+    for ((host, (certFile, sslCtx)) <- hosts) {
+      certMapping.add(host, readFile(certFile))
+      certFileMapping.add(host, certFile)
+      ctxMapping.add(host, sslCtx)
+    }
+
+    TlsHostConfig(certMapping, certFileMapping, ctxMapping)
+  }
+
+  private def readFile(f: File): String = new String(Files.readAllBytes(f.toPath), UTF_8)
+}
+
+/**
+ * Channel handler for the initial login messages of a labrad connection.
+ *
+ * At the end of a successful login, this handler removes itself from the
+ * channel pipeline and instead adds an appropriate client or server handler
+ * to handle subsequent data, depending on the connection type.
+ */
+class LoginHandler(
+  auth: AuthService,
+  hub: Hub,
+  tracker: StatsTracker,
+  messager: Messager,
+  tlsHostConfig: TlsHostConfig,
+  tlsPolicy: TlsPolicy
+)(implicit ec: ExecutionContext)
 extends SimpleChannelInboundHandler[Packet] with Logging {
+
+  override def channelActive(ctx: ChannelHandlerContext): Unit = {
+    isLocalConnection = (ctx.channel.remoteAddress, ctx.channel.localAddress) match {
+      case (remote: InetSocketAddress, local: InetSocketAddress) =>
+        remote.getAddress.isLoopbackAddress || remote.getAddress == local.getAddress
+
+      case _ =>
+        false
+    }
+    log.info(s"remote=${ctx.channel.remoteAddress}, local=${ctx.channel.localAddress}, isLocalConnection=$isLocalConnection")
+  }
 
   override def channelRead0(ctx: ChannelHandlerContext, packet: Packet): Unit = {
     val Packet(req, target, context, records) = packet
@@ -34,15 +99,54 @@ extends SimpleChannelInboundHandler[Packet] with Logging {
     ctx.close()
   }
 
+  // whether the connection originated from localhost (if so, we allow unencrypted connections)
+  private var isLocalConnection: Boolean = false
+
+  // whether the connection is secure (either because this is a tls-only channel
+  // or we have upgraded with STARTTLS to a secure connection.
+  private var isSecure: Boolean = tlsPolicy == TlsPolicy.ON
+
   private val challenge = Array.ofDim[Byte](256)
   Random.nextBytes(challenge)
 
-  private var handle: (ChannelHandlerContext, Packet) => Data = handleLogin
+  private var handle: (ChannelHandlerContext, Packet) => Data = {
+    import TlsPolicy._
+    tlsPolicy match {
+      case STARTTLS | STARTTLS_OPT | STARTTLS_FORCE => handleStartTls
+      case ON | OFF => handleLogin
+    }
+  }
+
+  private def handleStartTls(ctx: ChannelHandlerContext, packet: Packet): Data = packet match {
+    case Packet(req, 1, _, Seq(Record(1, Cluster(Str("STARTTLS"), Str(host))))) =>
+      val sslContext = tlsHostConfig.sslCtxs.map(host)
+      val engine = sslContext.newEngine(ctx.alloc())
+      val sslHandler = new SslHandler(engine, true)
+      ctx.pipeline.addFirst(sslHandler)
+      isSecure = true // now upgraded to TLS
+      handle = handleLogin
+      Str(tlsHostConfig.certs.map(host))
+
+    case _ =>
+      val requireStartTls = tlsPolicy match {
+        case TlsPolicy.STARTTLS_FORCE => true
+        case TlsPolicy.STARTTLS if !isLocalConnection => true
+        case _ => false
+      }
+      if (requireStartTls) {
+        throw LabradException(2, "Expected STARTTLS")
+      }
+      handleLogin(ctx, packet)
+  }
 
   private def handleLogin(ctx: ChannelHandlerContext, packet: Packet): Data = packet match {
     case Packet(req, 1, _, Seq()) if req > 0 =>
       handle = handleChallengeResponse
       Bytes(challenge)
+
+    case Packet(req, 1, _, Seq(Record(2, Str("PING")))) =>
+      Str("PONG")
+
     case _ =>
       throw LabradException(1, "Invalid login packet")
   }

--- a/src/main/scala/org/labrad/util/Futures.scala
+++ b/src/main/scala/org/labrad/util/Futures.scala
@@ -1,0 +1,25 @@
+package org.labrad.util
+
+import io.netty.util.concurrent.{Future => NettyFuture, GenericFutureListener}
+import scala.concurrent.{Future, Promise}
+
+object Futures {
+
+  /**
+   * Add a .toScala method to netty futures to convert them to scala futures.
+   */
+  implicit class RichNettyFuture[A](val future: NettyFuture[A]) extends AnyVal {
+    def toScala: Future[A] = {
+      val p = Promise[A]
+      future.addListener(new GenericFutureListener[NettyFuture[A]] {
+        def operationComplete(f: NettyFuture[A]) {
+          f.isSuccess match {
+            case true => p.success(f.getNow)
+            case false => p.failure(f.cause)
+          }
+        }
+      })
+      p.future
+    }
+  }
+}

--- a/src/main/scala/org/labrad/util/Paths.scala
+++ b/src/main/scala/org/labrad/util/Paths.scala
@@ -1,0 +1,20 @@
+package org.labrad.util
+
+import java.io.File
+
+
+/**
+ * Helpers for dealing with files and paths.
+ *
+ * Adds a method '/' to both strings and File objects, so that we can create file references
+ * in a convenient notation by writing, for example: "foo" / "bar".
+ */
+object Paths {
+  implicit class PathString(val path: String) extends AnyVal {
+    def / (file: String): File = new File(path, file)
+  }
+
+  implicit class PathFile(val path: File) extends AnyVal {
+    def / (file: String): File = new File(path, file)
+  }
+}

--- a/src/main/scala/org/labrad/util/package.scala
+++ b/src/main/scala/org/labrad/util/package.scala
@@ -112,6 +112,19 @@ object Util {
   }
 
   /**
+   * Parse a command line arg into a boolean value.
+   *
+   * true values: on, yes, y, true, t, 1
+   * false values: off, no, n, false, f, 0
+   */
+  def parseBooleanOpt(arg: String): Boolean = {
+    arg.toLowerCase match {
+      case "on" | "yes" | "y" | "true" | "t" | "1" => true
+      case "off" | "no" | "n" | "false" | "f" | "0" => false
+    }
+  }
+
+  /**
    * Drop the query and fragment from a URI.
    */
   def bareUri(uri: URI): URI = {

--- a/src/test/scala/org/labrad/ClientTest.scala
+++ b/src/test/scala/org/labrad/ClientTest.scala
@@ -14,8 +14,8 @@ import scala.concurrent.duration._
 class ClientTests extends FunSuite /*with Logging*/ {
 
   def testWithClient(name: String)(func: Client => Unit) = test(name) {
-    TestUtils.withManager { (host, port, password) =>
-      TestUtils.withClient(host = host, port = port, password = password) { c =>
+    TestUtils.withManager() { m =>
+      TestUtils.withClient(host = m.host, port = m.port, password = m.password) { c =>
         func(c)
       }
     }

--- a/src/test/scala/org/labrad/ManagerTest.scala
+++ b/src/test/scala/org/labrad/ManagerTest.scala
@@ -13,13 +13,13 @@ class ManagerTest extends FunSuite with AsyncAssertions {
   def mgr(c: Client) = new ManagerServerProxy(c)
 
   test("manager returns lists of servers and settings") {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
         val servers = await(mgr(c).servers)
         assert(servers.size == 2)
         assert(servers.exists { case (1L, "Manager") => true; case _ => false })
         assert(servers.exists { case (_, "Registry") => true; case _ => false })
-        withServer(host, port, password) { s =>
+        withServer(m.host, m.port, m.password) { s =>
           val servers2 = await(mgr(c).servers)
           assert(servers2.size == 3)
           assert(servers2.exists { case (_, "Scala Test Server") => true; case _ => false })
@@ -29,15 +29,15 @@ class ManagerTest extends FunSuite with AsyncAssertions {
   }
 
   test("manager uses same id when a server reconnects") {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
-        val id = withServer(host, port, password) { s =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
+        val id = withServer(m.host, m.port, m.password) { s =>
           await(mgr(c).lookupServer("Scala Test Server"))
         }
         Thread.sleep(10000)
         val servers = await(mgr(c).servers)
         assert(!servers.exists { case (_, "Scala Test Server") => true; case _ => false })
-        val id2 = withServer(host, port, password) { s =>
+        val id2 = withServer(m.host, m.port, m.password) { s =>
           await(mgr(c).lookupServer("Scala Test Server"))
         }
         assert(id == id2)
@@ -46,8 +46,8 @@ class ManagerTest extends FunSuite with AsyncAssertions {
   }
 
   test("manager sends message when server connects and disconnects") {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
 
         val connectWaiter = new Waiter
         val disconnectWaiter = new Waiter
@@ -69,7 +69,7 @@ class ManagerTest extends FunSuite with AsyncAssertions {
 
         await(mgr(c).subscribeToNamedMessage("Server Connect", connectId, true))
         await(mgr(c).subscribeToNamedMessage("Server Disconnect", disconnectId, true))
-        withServer(host, port, password) { s =>
+        withServer(m.host, m.port, m.password) { s =>
           connectWaiter.await(timeout(30.seconds))
         }
         disconnectWaiter.await(timeout(30.seconds))
@@ -80,18 +80,18 @@ class ManagerTest extends FunSuite with AsyncAssertions {
   }
 
   test("manager sends named messages when contexts expire") {
-    withManager { (host, port, password) =>
+    withManager() { m =>
       val expireAllWaiter = new Waiter
       val expireContextWaiter = new Waiter
 
       val expireAllId = 1234
       val expireContextId = 2345
 
-      withClient(host, port, password) { c =>
+      withClient(m.host, m.port, m.password) { c =>
 
         await(mgr(c).subscribeToNamedMessage("Expire All", expireAllId, true))
         await(mgr(c).subscribeToNamedMessage("Expire Context", expireContextId, true))
-        withClient(host, port, password) { c2 =>
+        withClient(m.host, m.port, m.password) { c2 =>
           // after requesting expiration, should get an expire context message
           val context = Context(c2.id, 20)
           c.addMessageListener {

--- a/src/test/scala/org/labrad/RegistryTest.scala
+++ b/src/test/scala/org/labrad/RegistryTest.scala
@@ -89,8 +89,8 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
   }
 
   test("registry can store and retrieve arbitrary data") {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
         await(c.send("Registry", "mkdir" -> Str("test"), "cd" -> Str("test")))
         try {
           for (i <- 0 until 1000) {
@@ -109,8 +109,8 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
   }
 
   test("registry can deal with unicode and strange characters in directory names", Tag("chars")) {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
         val dir = "<\u03C0|\u03C1>??+*\\/:|"
         await(c.send("Registry", "mkdir" -> Str(dir)))
         val (dirs, _) = await(c.send("Registry", "dir" -> Data.NONE))(0).get[(Seq[String], Seq[String])]
@@ -121,8 +121,8 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
   }
 
   test("registry can deal with unicode and strange characters in key names", Tag("chars")) {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
         val key = "<\u03C0|\u03C1>??+*\\/:|"
         val data = Str("Hello!")
         await(c.send("Registry", "set" -> Cluster(Str(key), Str("Hello!"))))
@@ -135,8 +135,8 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
   }
 
   test("registry cd with no arguments stays in same directory") {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
         await(c.send("Registry", "cd" -> Cluster(Arr(Str("test"), Str("a")), Bool(true))))
         val result = await(c.send("Registry", "cd" -> Data.NONE))(0)
         assert(result.get[Seq[String]] == Seq("", "test", "a"))
@@ -145,8 +145,8 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
   }
 
   test("registry sends message when key is created") {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
 
         val w = new Waiter
 
@@ -167,8 +167,8 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
   }
 
   test("registry sends message when key is changed") {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
 
         val w = new Waiter
 
@@ -190,8 +190,8 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
   }
 
   test("registry sends message when key is deleted") {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
 
         val w = new Waiter
 
@@ -213,8 +213,8 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
   }
 
   test("deleting a registry directory containing a dir should fail") {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
 
         val reg = new RegistryServerProxy(c)
         await(reg.cd(Seq("a", "b"), true))
@@ -238,8 +238,8 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
   }
 
   test("deleting a registry directory containing a key should fail") {
-    withManager { (host, port, password) =>
-      withClient(host, port, password) { c =>
+    withManager() { m =>
+      withClient(m.host, m.port, m.password) { c =>
 
         val reg = new RegistryServerProxy(c)
         await(reg.cd(Seq("a"), true))

--- a/src/test/scala/org/labrad/ServerConfigTest.scala
+++ b/src/test/scala/org/labrad/ServerConfigTest.scala
@@ -103,4 +103,66 @@ class ServerConfigTest extends FunSuite {
     val Success(config) = ServerConfig.fromCommandLine(Array())
     assert(config.nameOpt == None)
   }
+
+
+  test("tls-port can be set from environment variable") {
+    val Success(config) = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "7777"))
+    assert(config.tlsPort == 7777)
+  }
+
+  test("tls-port can be set from command line") {
+    val Success(config1) = ServerConfig.fromCommandLine(Array("--tls-port", "7777"))
+    assert(config1.tlsPort == 7777)
+
+    val Success(config2) = ServerConfig.fromCommandLine(Array("--tls-port=7878"))
+    assert(config2.tlsPort == 7878)
+  }
+
+  test("tls-port command line arg overrides environment variable") {
+    val Success(config) = ServerConfig.fromCommandLine(
+      Array("--tls-port=1234"),
+      env = Map("LABRAD_TLS_PORT" -> "2345"))
+    assert(config.tlsPort == 1234)
+  }
+
+  test("tls-port env var must be an integer") {
+    val tryConfig = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "foo"))
+    assert(tryConfig.isInstanceOf[Failure[_]])
+  }
+
+  test("tls-port command line must be an integer") {
+    val tryConfig = ServerConfig.fromCommandLine(Array("--tls-port=foo"))
+    assert(tryConfig.isInstanceOf[Failure[_]])
+  }
+
+
+  test("tls mode can be set from environment variable") {
+    val Success(config) = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS" -> "on"))
+    assert(config.tls == TlsMode.ON)
+  }
+
+  test("tls mode can be set from command line") {
+    val Success(config1) = ServerConfig.fromCommandLine(Array("--tls", "on"))
+    assert(config1.tls == TlsMode.ON)
+
+    val Success(config2) = ServerConfig.fromCommandLine(Array("--tls=on"))
+    assert(config2.tls == TlsMode.ON)
+  }
+
+  test("tls mode command line arg overrides environment variable") {
+    val Success(config) = ServerConfig.fromCommandLine(
+      Array("--tls=off"),
+      env = Map("LABRAD_TLS" -> "on"))
+    assert(config.tls == TlsMode.OFF)
+  }
+
+  test("tls mode env var must be a valid option") {
+    val tryConfig = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS" -> "foo"))
+    assert(tryConfig.isInstanceOf[Failure[_]])
+  }
+
+  test("tls mode command line must be a valid option") {
+    val tryConfig = ServerConfig.fromCommandLine(Array("--tls=foo"))
+    assert(tryConfig.isInstanceOf[Failure[_]])
+  }
 }

--- a/src/test/scala/org/labrad/ServerTest.scala
+++ b/src/test/scala/org/labrad/ServerTest.scala
@@ -193,10 +193,10 @@ class ServerTest extends FunSuite with AsyncAssertions {
   type FixtureParam = Fixture
 
   def withFixture(test: OneArgTest) = {
-    withManager { (host, port, password) =>
-      withServer(host, port, password) { server =>
-        withClient(host, port, password) { client =>
-          withFixture(test.toNoArgTest(Fixture(server, client, host, port, password)))
+    withManager() { m =>
+      withServer(m.host, m.port, m.password) { server =>
+        withClient(m.host, m.port, m.password) { client =>
+          withFixture(test.toNoArgTest(Fixture(server, client, m.host, m.port, m.password)))
         }
       }
     }

--- a/src/test/scala/org/labrad/TlsTest.scala
+++ b/src/test/scala/org/labrad/TlsTest.scala
@@ -1,0 +1,80 @@
+package org.labrad
+
+import java.io.File
+import org.labrad.data._
+import org.labrad.manager.TlsPolicy
+import org.labrad.types._
+import org.scalatest.FunSuite
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class TlsTest extends FunSuite {
+
+  import TestUtils._
+
+  def connectWithMode(tls: TlsMode, includeCerts: Boolean = true)(implicit m: ManagerInfo): Unit = {
+    val certs = if (includeCerts) {
+      Map(m.host -> m.tlsHosts.certFiles.map(m.host))
+    } else {
+      Map.empty[String, File]
+    }
+    withClient(m.host, m.port, m.password, tls = tls, tlsCerts = certs) { c =>
+      val mgr = new ManagerServerProxy(c)
+      Await.result(mgr.servers(), 1.second)
+    }
+  }
+
+  test("when manager TLS is ON, initial client connection must use TLS") {
+    withManager(TlsPolicy.ON) { implicit m =>
+      intercept[Exception] { connectWithMode(TlsMode.OFF) }
+      intercept[Exception] { connectWithMode(TlsMode.STARTTLS) }
+      intercept[Exception] { connectWithMode(TlsMode.STARTTLS_FORCE) }
+      connectWithMode(TlsMode.ON)
+    }
+  }
+
+  test("when manager TLS is OFF, client connection must not use TLS or STARTTLS") {
+    withManager(TlsPolicy.OFF) { implicit m =>
+      connectWithMode(TlsMode.OFF)
+      connectWithMode(TlsMode.STARTTLS) // localhost; will not send STARTTLS
+      intercept[Exception] { connectWithMode(TlsMode.STARTTLS_FORCE) }
+      intercept[Exception] { connectWithMode(TlsMode.ON) }
+    }
+  }
+
+  test("when manager TLS is STARTTLS, client connection may use STARTTLS") {
+    withManager(TlsPolicy.STARTTLS) { implicit m =>
+      connectWithMode(TlsMode.OFF)
+      connectWithMode(TlsMode.STARTTLS)
+      connectWithMode(TlsMode.STARTTLS_FORCE)
+      intercept[Exception] { connectWithMode(TlsMode.ON) }
+    }
+  }
+
+  test("when manager TLS is STARTTLS_OPT, client connection may use STARTTLS") {
+    withManager(TlsPolicy.STARTTLS_OPT) { implicit m =>
+      connectWithMode(TlsMode.OFF)
+      connectWithMode(TlsMode.STARTTLS) // localhost; will not actually STARTTLS
+      connectWithMode(TlsMode.STARTTLS_FORCE)
+      intercept[Exception] { connectWithMode(TlsMode.ON) }
+    }
+  }
+
+  test("when manager TLS is STARTTLS_FORCE, client connection must use STARTTLS") {
+    withManager(TlsPolicy.STARTTLS_FORCE) { implicit m =>
+      intercept[Exception] { connectWithMode(TlsMode.OFF) }
+      intercept[Exception] { connectWithMode(TlsMode.STARTTLS) }
+      connectWithMode(TlsMode.STARTTLS_FORCE)
+      intercept[Exception] { connectWithMode(TlsMode.ON) }
+    }
+  }
+
+  test("client fails to connect if manager cert is not trusted") {
+    withManager(TlsPolicy.ON) { implicit m =>
+      intercept[Exception] { connectWithMode(TlsMode.ON, includeCerts = false) }
+    }
+    withManager(TlsPolicy.STARTTLS_FORCE) { implicit m =>
+      intercept[Exception] { connectWithMode(TlsMode.STARTTLS_FORCE, includeCerts = false) }
+    }
+  }
+}

--- a/src/test/scala/org/labrad/manager/ManagerConfigTest.scala
+++ b/src/test/scala/org/labrad/manager/ManagerConfigTest.scala
@@ -1,5 +1,6 @@
 package org.labrad.manager
 
+import java.io.File
 import java.net.URI
 import org.scalatest.FunSuite
 import scala.util.{Failure, Success}
@@ -95,5 +96,124 @@ class ManagerConfigTest extends FunSuite {
       Array("--registry=/var/labrad/registry/for-real/"),
       env = Map("LABRADREGISTRY" -> "/var/labrad/registry/not-this-time"))
     checkRegistry(config, "/var/labrad/registry/for-real/")
+  }
+
+
+  test("tls-port can be set from environment variable") {
+    val Success(config) = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "7777"))
+    assert(config.tlsPort == 7777)
+  }
+
+  test("tls-port can be set from command line") {
+    val Success(config1) = ManagerConfig.fromCommandLine(Array("--tls-port", "7777"))
+    assert(config1.tlsPort == 7777)
+
+    val Success(config2) = ManagerConfig.fromCommandLine(Array("--tls-port=7878"))
+    assert(config2.tlsPort == 7878)
+  }
+
+  test("tls-port command line arg overrides environment variable") {
+    val Success(config) = ManagerConfig.fromCommandLine(
+      Array("--tls-port=1234"),
+      env = Map("LABRAD_TLS_PORT" -> "2345"))
+    assert(config.tlsPort == 1234)
+  }
+
+  test("tls-port env var must be an integer") {
+    val tryConfig = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "foo"))
+    assert(tryConfig.isInstanceOf[Failure[_]])
+  }
+
+  test("tls-port command line must be an integer") {
+    val tryConfig = ManagerConfig.fromCommandLine(Array("--tls-port=foo"))
+    assert(tryConfig.isInstanceOf[Failure[_]])
+  }
+
+
+  test("tls-required can be set from environment variable") {
+    val Success(config) = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_REQUIRED" -> "no"))
+    assert(config.tlsRequired == false)
+  }
+
+  test("tls-required can be set from command line") {
+    val Success(config1) = ManagerConfig.fromCommandLine(Array("--tls-required", "no"))
+    assert(config1.tlsRequired == false)
+
+    val Success(config2) = ManagerConfig.fromCommandLine(Array("--tls-required=no"))
+    assert(config2.tlsRequired == false)
+  }
+
+  test("tls-required command line arg overrides environment variable") {
+    val Success(config) = ManagerConfig.fromCommandLine(
+      Array("--tls-required=no"),
+      env = Map("LABRAD_TLS_REQUIRED" -> "yes"))
+    assert(config.tlsRequired == false)
+  }
+
+  test("tls-required env var must be a valid option") {
+    val tryConfig = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_REQUIRED" -> "foo"))
+    assert(tryConfig.isInstanceOf[Failure[_]])
+  }
+
+  test("tls-required command line must be a valid option") {
+    val tryConfig = ManagerConfig.fromCommandLine(Array("--tls-required=foo"))
+    assert(tryConfig.isInstanceOf[Failure[_]])
+  }
+
+
+  test("tls-hosts can be set from environment variable") {
+    val Success(config) = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_HOSTS" -> "foo.com"))
+    assert(config.tlsHosts == Map("foo.com" -> CertConfig.SelfSigned))
+  }
+
+  test("tls-hosts can be set from command line") {
+    val Success(config1) = ManagerConfig.fromCommandLine(Array("--tls-hosts", "foo.com"))
+    assert(config1.tlsHosts == Map("foo.com" -> CertConfig.SelfSigned))
+
+    val Success(config2) = ManagerConfig.fromCommandLine(Array("--tls-hosts=foo.com"))
+    assert(config2.tlsHosts == Map("foo.com" -> CertConfig.SelfSigned))
+  }
+
+  test("tls-hosts command line arg overrides environment variable") {
+    val Success(config) = ManagerConfig.fromCommandLine(
+      Array("--tls-hosts=foo.com"),
+      env = Map("LABRAD_TLS_HOSTS" -> "bar.com"))
+    assert(config.tlsHosts == Map("foo.com" -> CertConfig.SelfSigned))
+  }
+
+  test("tls-hosts may contain cert and key files") {
+    val Success(config1) = ManagerConfig.fromCommandLine(Array(
+      "--tls-hosts=foo.com?cert=/my/cert/file.crt&key=/my/key/file.pem"))
+    assert(config1.tlsHosts == Map(
+      "foo.com" -> CertConfig.Files(
+        cert = new File("/my/cert/file.crt"),
+        key = new File("/my/key/file.pem"))))
+
+    val Success(config2) = ManagerConfig.fromCommandLine(Array(
+      "--tls-hosts=foo.com?cert=/my/cert/file.crt&key=/my/key/file.pem&intermediates=/my/interm/file.pem"))
+    assert(config2.tlsHosts == Map(
+      "foo.com" -> CertConfig.Files(
+        cert = new File("/my/cert/file.crt"),
+        key = new File("/my/key/file.pem"),
+        intermediates = Some(new File("/my/interm/file.pem")))))
+  }
+
+  test("tls-hosts must provide cert and key if either is provided") {
+    val tryConfig1 = ManagerConfig.fromCommandLine(Array("--tls-hosts=foo.com?cert=/my/cert/file.crt"))
+    assert(tryConfig1.isInstanceOf[Failure[_]])
+
+    val tryConfig2 = ManagerConfig.fromCommandLine(Array("--tls-hosts=foo.com?key=/my/key/file.pem"))
+    assert(tryConfig2.isInstanceOf[Failure[_]])
+  }
+
+  test("tls-hosts may contain multiple semicolon-separated hosts") {
+    val Success(config) = ManagerConfig.fromCommandLine(Array(
+      "--tls-hosts=private1;public.com?cert=/my/cert/file.crt&key=/my/key/file.pem;private2"))
+    assert(config.tlsHosts == Map(
+      "private1" -> CertConfig.SelfSigned,
+      "private2" -> CertConfig.SelfSigned,
+      "public.com" -> CertConfig.Files(
+        cert = new File("/my/cert/file.crt"),
+        key = new File("/my/key/file.pem"))))
   }
 }


### PR DESCRIPTION
Modifies the manager to support TLS for labrad connections. The manager will continue to listen for unencrypted connections on port 7682 (configurable with `LABRADPORT` or the `--port` command line flag). If the connection originates from the loopback address on the same host, encryption is not required, but if this is a remote connection and the manager is configured to require TLS, then the client must send a STARTTLS command to initiate a TLS handshake and secure the connection. The manager also listens on port 7643 (configurable with `LABRAD_TLS_PORT` or the `--tls-port` command line flag) for connections that are encrypted to being with; these connections can be established with fewer network roundtrips.

For clients, there is an additional environment variable `LABRAD_TLS` which specifies the default mode to use when connecting to the manager. This can be either `starttls` (the default; connects to the plaintext port and then use starttls to upgrade the channel), `on` (connects to the tls port so that the connection is secure from the start), or `off` (no tls; for connecting to legacy managers).

When running the manager, the environment variable `LABRAD_TLS_HOSTS` or command line flag `--tls-hosts` can be used to configure the hostnames and certificates used during the TLS negotiation. Hostnames can be specified without any certs, in which case the manager will generate and store a self-signed certificate for that hostname which must then be installed on client machines so that they will trust the certificate when connecting to the manager. Alternately, you can specify the certificate and key files to use for a given hostname, for example if you have certs from a trusted certificate authority.
