### PR TITLE
Fix handling of default and optional args in server settings.

### DIFF
--- a/src/main/scala/org/labrad/types/Type.scala
+++ b/src/main/scala/org/labrad/types/Type.scala
@@ -194,6 +194,30 @@ object Pattern {
       case ps => PChoice(ps: _*)
     }
   }
+
+  /**
+   * Determine whether a given pattern accepts another pattern.
+   *
+   * This handles correctly the case where either pattern is a PChoice, which
+   * the accepts methods on individual Pattern subclasses do not.
+   * TODO: refactor accepts methods on Pattern subclasses to use this, so they
+   * will work against all patterns, including PChoice.
+   */
+  def accepts(a: Pattern, b: Pattern): Boolean = {
+    (a, b) match {
+      case (PChoice(as @ _*), PChoice(bs @ _*)) =>
+        bs.forall(b => as.exists(a => a.accepts(b)))
+
+      case (PChoice(as @ _*), b) =>
+        as.exists(a => a.accepts(b))
+
+      case (a, PChoice(bs @ _*)) =>
+        bs.forall(b => a.accepts(b))
+
+      case (a, b) =>
+        a.accepts(b)
+    }
+  }
 }
 
 


### PR DESCRIPTION
Found these issues while converting the qubit sequencer to scalabrad. Previously, the reflection code was creating accepted types for settings that were too flexible, basically allowing every parameter that has a default value or accepts an Option type to be individually passed None. However, with current labrad clients we really can only omit arguments back to front because we can't embed None inside a cluster (yet). Also adds some tests both of the accepted types and the actual handler dispatch when calling these methods.

@DanielSank 
