### PR TITLE
Fix registry notifications when connecting to a remote registry

### DIFF
--- a/src/main/scala/org/labrad/Proxies.scala
+++ b/src/main/scala/org/labrad/Proxies.scala
@@ -119,6 +119,9 @@ trait RegistryServer extends Requester {
 
   def notifyOnChange(id: Long, enable: Boolean): Future[Unit] =
     callUnit("Notify on Change", UInt(id), Bool(enable))
+
+  def streamChanges(id: Long, enable: Boolean): Future[Unit] =
+    callUnit("Stream Changes", UInt(id), Bool(enable))
 }
 
 class RegistryServerProxy(cxn: Connection, name: String = "Registry", context: Context = Context(0, 0))

--- a/src/main/scala/org/labrad/registry/FileStore.scala
+++ b/src/main/scala/org/labrad/registry/FileStore.scala
@@ -61,7 +61,7 @@ abstract class FileStore(rootDir: File) extends RegistryStore {
     (dirs, keys)
   }
 
-  def child(parent: File, name: String, create: Boolean): (File, Boolean) = {
+  def childImpl(parent: File, name: String, create: Boolean): (File, Boolean) = {
     val dir = new File(parent, encode(name) + DIR_EXT)
     val created = if (dir.exists) {
       false
@@ -73,8 +73,8 @@ abstract class FileStore(rootDir: File) extends RegistryStore {
     (dir, created)
   }
 
-  def rmDir(dir: File, name: String): Unit = {
-    val (path, created) = child(dir, name, create = false)
+  def rmDirImpl(dir: File, name: String): Unit = {
+    val path = child(dir, name, create = false)
     if (!path.exists) sys.error(s"directory does not exist: $name")
     if (path.isFile) sys.error(s"found file instead of directory: $name")
     path.delete()
@@ -95,13 +95,13 @@ abstract class FileStore(rootDir: File) extends RegistryStore {
     }
   }
 
-  def setValue(dir: File, key: String, value: Data): Unit = {
+  def setValueImpl(dir: File, key: String, value: Data): Unit = {
     val path = keyFile(dir, key)
     val bytes = encodeData(value)
     writeFile(path, bytes)
   }
 
-  def delete(dir: File, key: String): Unit = {
+  def deleteImpl(dir: File, key: String): Unit = {
     val path = keyFile(dir, key)
     if (!path.exists) sys.error(s"key does not exist: $key")
     if (path.isDirectory) sys.error(s"found directory instead of file: $key")

--- a/src/main/scala/org/labrad/registry/Migrate.scala
+++ b/src/main/scala/org/labrad/registry/Migrate.scala
@@ -209,7 +209,7 @@ object Migrate {
     private def find(path: Seq[String], create: Boolean = false): store.Dir = {
       var loc = store.root
       for (dir <- path; if dir.nonEmpty) {
-        loc = store.child(loc, dir, create = create)._1
+        loc = store.child(loc, dir, create = create)
       }
       loc
     }

--- a/src/main/scala/org/labrad/registry/Registry.scala
+++ b/src/main/scala/org/labrad/registry/Registry.scala
@@ -25,6 +25,8 @@ trait RegistryStore {
   def getValue(dir: Dir, key: String, default: Option[(Boolean, Data)]): Data
   def setValue(dir: Dir, key: String, value: Data): Unit
   def delete(dir: Dir, key: String): Unit
+
+  def notifyOnChange(listener: (Dir, String, Boolean, Boolean) => Unit): Unit = {}
 }
 
 class Registry(id: Long, name: String, store: RegistryStore, hub: Hub, tracker: StatsTracker)
@@ -79,17 +81,21 @@ extends ServerActor with Logging {
   }
 
   // send a notification to all contexts that have listeners registered
-  private def messageContexts(dir: store.Dir, name: String, isDir: Boolean, addOrChange: Boolean) = {
+  private def notifyContexts(dir: store.Dir, name: String, isDir: Boolean, addOrChange: Boolean) = {
     for ((ctx, _) <- contexts.values) {
-      ctx.message(dir, name, isDir, addOrChange)
+      ctx.notify(dir, name, isDir, addOrChange)
     }
   }
+
+  // tell the backend to call us if it detects changes that we didn't trigger
+  store.notifyOnChange(notifyContexts)
 
   // contains context-specific state and settings
   class RegistryContext(context: Context) {
 
     private var curDir = store.root
-    private var changeListener: Option[(Long, Long)] = None // TODO: allow a context to send notifications to more than one target
+    private var changeListener: Option[(Long, Long)] = None
+    private var allChangeListener: Option[(Long, Long)] = None
 
     @Setting(id=1,
              name="dir",
@@ -145,7 +151,7 @@ extends ServerActor with Logging {
       if (create) require(name.nonEmpty, "Cannot create a directory with an empty name")
       val (newDir, created) = store.child(dir, name, create)
       if (created) {
-        messageContexts(dir, name, isDir=true, addOrChange=true)
+        notifyContexts(dir, name, isDir=true, addOrChange=true)
       }
       newDir
     }
@@ -155,7 +161,7 @@ extends ServerActor with Logging {
              doc="Delete the given subdirectory from the current directory")
     def rmDir(name: String): Unit = {
       store.rmDir(curDir, name)
-      messageContexts(curDir, name, isDir=true, addOrChange=false)
+      notifyContexts(curDir, name, isDir=true, addOrChange=false)
     }
 
     @Setting(id=20,
@@ -178,7 +184,7 @@ extends ServerActor with Logging {
     def setValue(key: String, value: Data): Unit = {
       require(key.nonEmpty, "Cannot create a key with empty name")
       store.setValue(curDir, key, value)
-      messageContexts(curDir, key, isDir=false, addOrChange=true)
+      notifyContexts(curDir, key, isDir=false, addOrChange=true)
     }
 
     @Setting(id=40,
@@ -186,7 +192,7 @@ extends ServerActor with Logging {
              doc="Delete the given key from the current directory")
     def delete(key: String): Unit = {
       store.delete(curDir, key)
-      messageContexts(curDir, key, isDir=false, addOrChange=false)
+      notifyContexts(curDir, key, isDir=false, addOrChange=false)
     }
 
     @Setting(id=50,
@@ -194,6 +200,13 @@ extends ServerActor with Logging {
              doc="Requests notifications if the contents of the current directory change")
     def notifyOnChange(r: RequestContext, id: Long, enable: Boolean): Unit = {
       changeListener = if (enable) Some((r.source, id)) else None
+    }
+
+    @Setting(id=55,
+             name="Stream Changes",
+             doc="Requests notifications of all changes made in any directory")
+    def streamChanges(r: RequestContext, id: Long, enable: Boolean): Unit = {
+      allChangeListener = if (enable) Some((r.source, id)) else None
     }
 
     @Setting(id=100,
@@ -216,7 +229,13 @@ extends ServerActor with Logging {
      * the message, and has a message listener registered, then we will
      * send a message of the form (s{dirOrKeyName}, b{isDir}, b{addOrChange})
      */
-    private[registry] def message(dir: store.Dir, name: String, isDir: Boolean, addOrChange: Boolean): Unit = {
+    private[registry] def notify(dir: store.Dir, name: String, isDir: Boolean, addOrChange: Boolean): Unit = {
+      for ((target, msgId) <- allChangeListener) {
+        log.debug(s"notify: ctx=${context} name=${name} isDir=${isDir} addOrChange=${addOrChange}")
+        val msg = Cluster(Arr(store.pathTo(dir).toArray), Str(name), Bool(isDir), Bool(addOrChange))
+        val pkt = Packet(0, target = id, context = context, records = Seq(Record(msgId, msg)))
+        hub.message(target, pkt)
+      }
       if (dir == curDir) {
         for ((target, msgId) <- changeListener) {
           log.debug(s"notify: ctx=${context} name=${name} isDir=${isDir} addOrChange=${addOrChange}")
@@ -228,4 +247,3 @@ extends ServerActor with Logging {
     }
   }
 }
-

--- a/src/main/scala/org/labrad/registry/RemoteStore.scala
+++ b/src/main/scala/org/labrad/registry/RemoteStore.scala
@@ -44,7 +44,7 @@ class RemoteStore(host: String, port: Int, password: Array[Char], tls: TlsMode) 
         cxn.addMessageListener {
           case Message(_, _, `id`, data) =>
             val (path, name, isDir, addOrChange) = data.get[(Seq[String], String, Boolean, Boolean)]
-            notifyContexts(path, name, isDir, addOrChange)
+            notifyListener(path, name, isDir, addOrChange)
         }
         cxn.connect()
         val registry = new RegistryServerProxy(cxn)

--- a/src/main/scala/org/labrad/registry/SQLiteStore.scala
+++ b/src/main/scala/org/labrad/registry/SQLiteStore.scala
@@ -104,7 +104,7 @@ class SQLiteStore(cxn: Connection) extends RegistryStore {
 
   def parent(dir: SqlDir): SqlDir = dir.parent
 
-  def child(dir: SqlDir, name: String, create: Boolean): (SqlDir, Boolean) = {
+  def childImpl(dir: SqlDir, name: String, create: Boolean): (SqlDir, Boolean) = {
     val idOpt = SQL"""
       SELECT id FROM dirs WHERE parent_id = ${dir.id} AND name = $name
     """.as(long("id").singleOpt)
@@ -125,7 +125,7 @@ class SQLiteStore(cxn: Connection) extends RegistryStore {
     (dirs, keys)
   }
 
-  def rmDir(dir: SqlDir, name: String): Unit = {
+  def rmDirImpl(dir: SqlDir, name: String): Unit = {
     SQL" DELETE FROM dirs WHERE parent_id = ${dir.id} AND name = $name ".execute()
   }
 
@@ -150,7 +150,7 @@ class SQLiteStore(cxn: Connection) extends RegistryStore {
     }
   }
 
-  def setValue(dir: SqlDir, key: String, value: Data): Unit = {
+  def setValueImpl(dir: SqlDir, key: String, value: Data): Unit = {
     val typ = value.t.toString
     val data = value.toBytes
 
@@ -161,7 +161,7 @@ class SQLiteStore(cxn: Connection) extends RegistryStore {
     }
   }
 
-  def delete(dir: SqlDir, key: String): Unit = {
+  def deleteImpl(dir: SqlDir, key: String): Unit = {
     // TODO: do we need to look at boolean return value here?
     SQL" DELETE FROM keys WHERE dir_id = ${dir.id} AND name = $key ".execute()
   }

--- a/src/test/scala/org/labrad/RegistryTest.scala
+++ b/src/test/scala/org/labrad/RegistryTest.scala
@@ -30,7 +30,7 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
   }
 
   testAllBackends("registry can store and retrieve arbitrary data") { (backend, exact) =>
-    val (loc, _) = backend.child(backend.root, "test", create = true)
+    val loc = backend.child(backend.root, "test", create = true)
     for (i <- 0 until 1000) {
       val tpe = Hydrant.randomType
       val data = Hydrant.randomData(tpe)

--- a/src/test/scala/org/labrad/TestUtils.scala
+++ b/src/test/scala/org/labrad/TestUtils.scala
@@ -27,15 +27,19 @@ object TestUtils extends {
 
   def await[A](future: Future[A]): A = Await.result(future, 30.seconds)
 
-  def withManager[T](tlsPolicy: TlsPolicy = TlsPolicy.OFF)(f: ManagerInfo => T): T = {
+  def defaultStore(): RegistryStore = {
+    val registryFile = File.createTempFile("labrad-registry", "")
+    SQLiteStore(registryFile)
+  }
+
+  def withManager[T](
+    tlsPolicy: TlsPolicy = TlsPolicy.OFF,
+    registryStore: RegistryStore = defaultStore()
+  )(f: ManagerInfo => T): T = {
     val host = "localhost"
     val port = 10000 + Random.nextInt(50000)
 
     val password = "testPassword12345!@#$%".toCharArray
-
-    val registryFile = File.createTempFile("labrad-registry", "")
-
-    val registryStore = SQLiteStore(registryFile)
 
     val ssc = new SelfSignedCertificate()
     val sslCtx = SslContextBuilder.forServer(ssc.certificate, ssc.privateKey).build()

--- a/src/test/scala/org/labrad/registry/RemoteStoreTest.scala
+++ b/src/test/scala/org/labrad/registry/RemoteStoreTest.scala
@@ -1,0 +1,124 @@
+package org.labrad.registry
+
+import org.labrad.{ManagerInfo, RegistryServerProxy, TlsMode}
+import org.labrad.annotations._
+import org.labrad.data._
+import org.labrad.registry._
+import org.labrad.types._
+import org.scalatest.{FunSuite, Matchers, Tag}
+import org.scalatest.concurrent.AsyncAssertions
+import org.scalatest.time.SpanSugar._
+import scala.collection._
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class RemoteStoreTest extends FunSuite with Matchers with AsyncAssertions {
+
+  import org.labrad.TestUtils._
+
+  def withManagers()(func: (ManagerInfo, ManagerInfo, ManagerInfo) => Unit): Unit = {
+    withManager() { root =>
+      val store1 = new RemoteStore(root.host, root.port, root.password, tls = TlsMode.OFF)
+      withManager(registryStore = store1) { leaf1 =>
+        val store2 = new RemoteStore(root.host, root.port, root.password, tls = TlsMode.OFF)
+        withManager(registryStore = store2) { leaf2 =>
+        }
+      }
+    }
+  }
+
+  test("remote registry gets message when key is created") {
+    withManagers() { (root, leaf1, leaf2) =>
+      withClient(leaf1.host, leaf1.port, leaf1.password) { c1 =>
+        withClient(leaf2.host, leaf2.port, leaf2.password) { c2 =>
+
+          val r1 = new RegistryServerProxy(c1)
+          val r2 = new RegistryServerProxy(c2)
+
+          val w = new Waiter
+
+          val msgId = 1234
+
+          c2.addMessageListener {
+            case Message(src, ctx, `msgId`, data) =>
+              w { assert(data == Cluster(Str("a"), Bool(false), Bool(true))) }
+              w.dismiss
+          }
+
+          await(r1.mkDir("test"))
+          await(r1.cd("test"))
+
+          await(r2.notifyOnChange(msgId, true))
+          await(r2.cd("test"))
+
+          await(r1.set("a", Str("test")))
+          w.await(timeout(10.seconds))
+        }
+      }
+    }
+  }
+
+  test("remote registry gets message when key is changed") {
+    withManagers() { (root, leaf1, leaf2) =>
+      withClient(leaf1.host, leaf1.port, leaf1.password) { c1 =>
+        withClient(leaf2.host, leaf2.port, leaf2.password) { c2 =>
+
+          val r1 = new RegistryServerProxy(c1)
+          val r2 = new RegistryServerProxy(c2)
+
+          val w = new Waiter
+
+          val msgId = 1234
+
+          c2.addMessageListener {
+            case Message(src, ctx, `msgId`, data) =>
+              w { assert(data == Cluster(Str("a"), Bool(false), Bool(true))) }
+              w.dismiss
+          }
+
+          await(r1.mkDir("test"))
+          await(r1.cd("test"))
+          await(r1.set("a", Str("first")))
+
+          await(r2.notifyOnChange(msgId, true))
+          await(r2.cd("test"))
+
+          await(r1.set("a", Str("second")))
+          w.await(timeout(10.seconds))
+        }
+      }
+    }
+  }
+
+  test("remote registry gets message when key is deleted") {
+    withManagers() { (root, leaf1, leaf2) =>
+      withClient(leaf1.host, leaf1.port, leaf1.password) { c1 =>
+        withClient(leaf2.host, leaf2.port, leaf2.password) { c2 =>
+
+          val r1 = new RegistryServerProxy(c1)
+          val r2 = new RegistryServerProxy(c2)
+
+          val w = new Waiter
+
+          val msgId = 1234
+
+          c2.addMessageListener {
+            case Message(src, ctx, `msgId`, data) =>
+              w { assert(data == Cluster(Str("a"), Bool(false), Bool(false))) }
+              w.dismiss
+          }
+
+          await(r1.mkDir("test"))
+          await(r1.cd("test"))
+          await(r1.set("a", Str("first")))
+
+          await(r2.notifyOnChange(msgId, true))
+          await(r2.cd("test"))
+
+          await(r1.del("a"))
+          w.await(timeout(10.seconds))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
To do this, we introduce a new setting to get all change notifications, not just those that happen in the current directory for a given context. When connecting to a remote registry, we are then able to get notified of any changes that happen, and send these changes to our listening contexts as appropriate. This also requires moving the notification logic into the RegistryStore backend so that we do not get double-notifications for changes we make (once when the change is made and again when the remote registry tells us about that change when it gets made there as well).
