### PR TITLE
Block incoming connections until registry is connected.

### DIFF
--- a/src/main/scala/org/labrad/manager/LoginHandler.scala
+++ b/src/main/scala/org/labrad/manager/LoginHandler.scala
@@ -7,6 +7,7 @@ import java.io.{ByteArrayOutputStream, File, FileInputStream}
 import java.net.{InetAddress, InetSocketAddress}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
+import java.util.concurrent.TimeoutException
 import org.labrad.ContextCodec
 import org.labrad.data._
 import org.labrad.errors._
@@ -185,6 +186,13 @@ extends SimpleChannelInboundHandler[Packet] with Logging {
 
         case _ =>
           throw LabradException(1, "Invalid identification packet")
+      }
+
+      try {
+        Await.result(hub.registryConnected, 30.seconds)
+      } catch {
+        case _: TimeoutException =>
+          throw LabradException(3, "Timeout while waiting for registry to connect")
       }
 
       // logged in successfully; add new handler to channel pipeline

--- a/src/main/scala/org/labrad/manager/Manager.scala
+++ b/src/main/scala/org/labrad/manager/Manager.scala
@@ -59,8 +59,7 @@ class CentralNode(
   tracker.connectServer(Manager.ID, Manager.NAME)
 
   for (store <- storeOpt) {
-    // Registry gets id 2L
-    val name = "Registry"
+    val name = Registry.NAME
     val id = hub.allocateServerId(name)
     val server = new Registry(id, name, store, hub, tracker)
     hub.connectServer(id, name, server)

--- a/src/main/scala/org/labrad/registry/Registry.scala
+++ b/src/main/scala/org/labrad/registry/Registry.scala
@@ -27,6 +27,10 @@ trait RegistryStore {
   def delete(dir: Dir, key: String): Unit
 }
 
+object Registry {
+  val NAME = "Registry"
+}
+
 class Registry(id: Long, name: String, store: RegistryStore, hub: Hub, tracker: StatsTracker)
 extends ServerActor with Logging {
 

--- a/src/test/scala/org/labrad/ReflectTest.scala
+++ b/src/test/scala/org/labrad/ReflectTest.scala
@@ -7,6 +7,7 @@ import org.labrad.manager.{ClientActor, Hub, ManagerImpl, ServerActor}
 import org.labrad.types.Pattern
 import org.labrad.util.Logging
 import org.scalatest.FunSuite
+import scala.concurrent.Future
 import scala.reflect.ClassTag
 import scala.reflect.runtime.{ currentMirror => cm, universe => ru }
 
@@ -377,6 +378,8 @@ class ReflectTests extends FunSuite with Logging {
         ServerInfo(2L, "Registry", "the registry", Seq())
       )
       def serverInfo(id: Either[Long, String]): Option[ServerInfo] = None
+
+      def registryConnected = Future.successful(())
     }
 
     val inst = new ManagerImpl(1L, "Manager", hub, null, null, null)


### PR DESCRIPTION
Most of our labrad code assumes that the registry will be available when connecting to the manager. In order to support having an external registry, we block other incoming connections until the registry has. This is not perfect because of course the registry could disconnect and reconnect later, but it's better than nothing.
