### PR TITLE
Add echo method to ManagerServerProxy

### DIFF
--- a/src/main/scala/org/labrad/Proxies.scala
+++ b/src/main/scala/org/labrad/Proxies.scala
@@ -87,6 +87,9 @@ trait ManagerServer extends Requester {
 
   def connectionInfo(): Future[Seq[(Long, String, Boolean, Long, Long, Long, Long, Long, Long)]] =
     call[Seq[(Long, String, Boolean, Long, Long, Long, Long, Long, Long)]]("Connection Info")
+
+  def echo(data: Data): Future[Data] =
+    call("Echo", data)
 }
 
 class ManagerServerProxy(cxn: Connection, name: String = "Manager", context: Context = Context(0, 0))


### PR DESCRIPTION
I want to use the manager echo setting as a simple way to ping managers in the multiheaded registry. It's very easy to add it to the manager proxy.
