### PR TITLE
Add support for username+password and OAuth login

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,9 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "anorm" % "2.4.0-M2",
   "org.xerial" % "sqlite-jdbc" % "3.8.11.2",
   "org.bouncycastle" % "bcprov-jdk15on" % "1.52",
-  "org.bouncycastle" % "bcpkix-jdk15on" % "1.52"
+  "org.bouncycastle" % "bcpkix-jdk15on" % "1.52",
+  "org.mindrot" % "jbcrypt" % "0.3m",
+  "com.google.api-client" % "google-api-client" % "1.19.0"
 )
 
 // When running, connect std in and tell manager to stop on EOF (ctrl+D).

--- a/src/main/scala/org/labrad/Proxies.scala
+++ b/src/main/scala/org/labrad/Proxies.scala
@@ -88,6 +88,9 @@ trait ManagerServer extends Requester {
   def connectionInfo(): Future[Seq[(Long, String, Boolean, Long, Long, Long, Long, Long, Long)]] =
     call[Seq[(Long, String, Boolean, Long, Long, Long, Long, Long, Long)]]("Connection Info")
 
+  def connectionUsername(id: Long): Future[String] =
+    call[String]("Connection Username", UInt(id))
+
   def echo(data: Data): Future[Data] =
     call("Echo", data)
 }

--- a/src/main/scala/org/labrad/data/ToData.scala
+++ b/src/main/scala/org/labrad/data/ToData.scala
@@ -58,6 +58,15 @@ object ToData {
     }
   }
 
+  implicit def seqToData[A](implicit aToData: ToData[A]) = new ToData[Seq[A]] {
+    def apply(b: DataBuilder, value: Seq[A]): Unit = {
+      b.array(value.length)
+      for (elem <- value) {
+        b.add(elem)
+      }
+    }
+  }
+
   implicit def tuple2ToData[T1, T2](implicit s1: ToData[T1], s2: ToData[T2]) = new ToData[(T1, T2)] {
     def apply(b: DataBuilder, value: (T1, T2)): Unit = {
       value match {

--- a/src/main/scala/org/labrad/data/package.scala
+++ b/src/main/scala/org/labrad/data/package.scala
@@ -12,10 +12,8 @@ package object data {
      * There must be a setter for this type T available
      * in implicit scope.
      */
-    def toData(tag: String)(implicit setter: Setter[T]): Data = {
-      val data = Data(tag)
-      data.set(value)
-      data
+    def toData(implicit builder: ToData[T]): Data = {
+      builder(value)
     }
   }
 

--- a/src/main/scala/org/labrad/manager/LoginHandler.scala
+++ b/src/main/scala/org/labrad/manager/LoginHandler.scala
@@ -157,7 +157,7 @@ extends SimpleChannelInboundHandler[Packet] with Logging {
       d
 
     case Packet(req, 1, _, Seq(Record(2, Str("PING")))) =>
-      Str("PONG:auth-server") // include manager features in ping response
+      ("PONG", Seq("auth-server")).toData // include manager features in ping response
 
     case Packet(req, 1, _, Seq(Record(Authenticator.METHODS_SETTING_ID, data))) =>
       val resp = doAuthRequest(Authenticator.METHODS_SETTING_ID, data)

--- a/src/main/scala/org/labrad/manager/LoginHandler.scala
+++ b/src/main/scala/org/labrad/manager/LoginHandler.scala
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeoutException
 import org.labrad.ContextCodec
 import org.labrad.data._
 import org.labrad.errors._
+import org.labrad.manager.auth._
 import org.labrad.types._
 import org.labrad.util._
 import scala.concurrent.ExecutionContext
@@ -114,6 +115,8 @@ extends SimpleChannelInboundHandler[Packet] with Logging {
   private val challenge = Array.ofDim[Byte](256)
   Random.nextBytes(challenge)
 
+  private var username: String = ""
+
   private var handle: (ChannelHandlerContext, Packet) => Data = {
     import TlsPolicy._
     tlsPolicy match {
@@ -154,10 +157,45 @@ extends SimpleChannelInboundHandler[Packet] with Logging {
       d
 
     case Packet(req, 1, _, Seq(Record(2, Str("PING")))) =>
-      Str("PONG")
+      Str("PONG:auth-server") // include manager features in ping response
+
+    case Packet(req, 1, _, Seq(Record(Authenticator.METHODS_SETTING_ID, data))) =>
+      val resp = doAuthRequest(Authenticator.METHODS_SETTING_ID, data)
+      (Seq("password") ++ resp.get[Seq[String]]).toData
+
+    case Packet(req, 1, _, Seq(Record(Authenticator.INFO_SETTING_ID, data))) =>
+      val resp = doAuthRequest(Authenticator.INFO_SETTING_ID, data)
+      resp
+
+    case Packet(req, 1, _, Seq(Record(Authenticator.AUTH_SETTING_ID, data))) =>
+      val resp = doAuthRequest(Authenticator.AUTH_SETTING_ID, data)
+      username = resp.get[String]
+      handle = handleIdentification
+      Str("LabRAD 2.0")
 
     case _ =>
       throw LabradException(1, "Invalid login packet")
+  }
+
+  private def doAuthRequest(setting: Long, data: Data): Data = {
+    if (!(isSecure || isLocalConnection)) {
+      throw LabradException(3, "External auth is only available with TLS")
+    }
+    try {
+      Await.result(hub.authServerConnected, 5.seconds)
+    } catch {
+      case _: TimeoutException =>
+        throw LabradException(4, "Timeout while waiting for auth server to connect")
+    }
+    val id = hub.getServerId(Authenticator.NAME)
+    val packet = Packet(1, 1, Context(1, 0), Seq(Record(setting, data)))
+    val f = hub.request(id, packet)(timeout = 5.seconds)
+    val respPacket = Await.result(f, 5.seconds)
+    val Packet(_, _, _, Seq(Record(_, resp))) = respPacket
+    if (resp.isError) {
+      throw LabradException(resp.getErrorCode, resp.getErrorMessage)
+    }
+    resp
   }
 
   private def handleChallengeResponse(ctx: ChannelHandlerContext, packet: Packet): Data = packet match {
@@ -165,6 +203,7 @@ extends SimpleChannelInboundHandler[Packet] with Logging {
       if (!auth.authenticate(challenge, response)) throw LabradException(2, "Incorrect password")
       handle = handleIdentification
       Str("LabRAD 2.0")
+
     case _ =>
       throw LabradException(1, "Invalid authentication packet")
   }
@@ -174,13 +213,13 @@ extends SimpleChannelInboundHandler[Packet] with Logging {
       val (handler, id) = data match {
         case Cluster(UInt(ver), Str(name)) =>
           val id = hub.allocateClientId(name)
-          val handler = new ClientHandler(hub, tracker, messager, ctx.channel, id, name)
+          val handler = new ClientHandler(hub, tracker, messager, ctx.channel, id, name, username)
           hub.connectClient(id, name, handler)
           (handler, id)
 
         case Cluster(UInt(ver), Str(name), Str(doc)) =>
           val id = hub.allocateServerId(name)
-          val handler = new ServerHandler(hub, tracker, messager, ctx.channel, id, name, doc)
+          val handler = new ServerHandler(hub, tracker, messager, ctx.channel, id, name, doc, username)
           hub.connectServer(id, name, handler)
           (handler, id)
 
@@ -188,7 +227,7 @@ extends SimpleChannelInboundHandler[Packet] with Logging {
         case Cluster(UInt(ver), Str(name), Str(docOrig), Str(notes)) =>
           val doc = if (notes.isEmpty) docOrig else (docOrig + "\n\n" + notes)
           val id = hub.allocateServerId(name)
-          val handler = new ServerHandler(hub, tracker, messager, ctx.channel, id, name, doc)
+          val handler = new ServerHandler(hub, tracker, messager, ctx.channel, id, name, doc, username)
           hub.connectServer(id, name, handler)
           (handler, id)
 

--- a/src/main/scala/org/labrad/manager/Manager.scala
+++ b/src/main/scala/org/labrad/manager/Manager.scala
@@ -62,8 +62,9 @@ class CentralNode(
     val name = Registry.NAME
     val id = hub.allocateServerId(name)
     val externalConfig = ServerConfig("", 0, password)
-    val registry = new Registry(id, name, store, hub, tracker, externalConfig)
-    hub.connectServer(id, name, new RegistryActor(registry, hub))
+    val registry = new Registry(id, name, regStore, externalConfig)
+    hub.setServerInfo(ServerInfo(registry.id, registry.name, registry.doc, registry.settings))
+    hub.connectServer(id, name, new LocalServerActor(registry, hub, tracker))
   }
 
   // start listening for incoming network connections

--- a/src/main/scala/org/labrad/manager/RemoteConnector.scala
+++ b/src/main/scala/org/labrad/manager/RemoteConnector.scala
@@ -1,0 +1,263 @@
+package org.labrad.manager
+
+import org.labrad._
+import org.labrad.annotations._
+import org.labrad.concurrent.{Chan, Send, Time}
+import org.labrad.concurrent.Go._
+import org.labrad.data._
+import org.labrad.errors._
+import org.labrad.registry.RegistryStore
+import org.labrad.types._
+import org.labrad.util.Logging
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+trait LocalServer {
+  def id: Long
+  def name: String
+  def doc: String
+  def settings: Seq[SettingInfo]
+
+  def message(src: String, packet: Packet): Unit
+  def request(src: String, packet: Packet, messageFunc: (Long, Packet) => Unit)(implicit timeout: Duration): Future[Packet]
+  def expireContext(src: String, context: Context)(implicit timeout: Duration): Future[Long]
+  def expireAll(src: String, high: Long)(implicit timeout: Duration): Future[Long]
+  def expireAll(src: String)(implicit timeout: Duration): Future[Unit]
+}
+
+class LocalServerActor(server: LocalServer, hub: Hub, tracker: StatsTracker) extends ServerActor {
+  val username = ""// Local servers running in manager process act like global user
+  val srcId = ""
+  private val messageFunc = (target: Long, pkt: Packet) => hub.message(target, pkt)
+
+  def message(packet: Packet): Unit = {
+    tracker.msgRecv(server.id)
+    server.message(srcId, packet)
+  }
+
+  def request(packet: Packet)(implicit timeout: Duration): Future[Packet] = {
+    tracker.serverReq(server.id)
+    val f = server.request(srcId, packet, messageFunc)
+    f.onComplete { _ =>
+      tracker.serverRep(server.id)
+    }
+    f
+  }
+
+  def expireContext(ctx: Context)(implicit timeout: Duration): Future[Long] = server.expireContext(srcId, ctx)
+  def expireAll(high: Long)(implicit timeout: Duration): Future[Long] = server.expireAll(srcId, high)
+
+  def close(): Unit = {}
+}
+
+class MultiheadServer(name: String, registry: RegistryStore, server: LocalServer, externalConfig: ServerConfig) extends Logging {
+  private val managers = mutable.Map.empty[(String, Int), RemoteConnector]
+
+  // connect to managers that are stored in the registry
+  refresh()
+
+  def list(): Seq[(String, Int, Boolean)] = {
+    managers.toSeq.map { case ((host, port), reg) =>
+      (host, port, reg.isConnected)
+    }.sorted
+  }
+
+  def refresh(): Unit = {
+    // load the list of managers from the registry
+    var dir = registry.root
+    dir = registry.child(dir, "Servers", create = true)
+    dir = registry.child(dir, name, create = true)
+    dir = registry.child(dir, "Multihead", create = true)
+    val default = DataBuilder("*(sws)").array(0).result()
+    val result = registry.getValue(dir, "Managers", default = Some((true, default)))
+    val configs = result.get[Seq[(String, Long, String)]].map {
+      case (host, port, pw) =>
+        externalConfig.copy(
+          host = host,
+          port = if (port != 0) port.toInt else externalConfig.port,
+          password = if (pw != "") pw.toCharArray else externalConfig.password
+        )
+    }
+    val urls = configs.map(c => s"${c.host}:${c.port}")
+    log.info(s"managers in registry: ${urls.mkString(", ")}")
+
+    // connect to any managers we are not already connected to
+    for (config <- configs) {
+      managers.getOrElseUpdate((config.host, config.port), {
+        new RemoteConnector(server, config)
+      })
+    }
+  }
+
+  def add(host: String, port: Option[Int], password: Option[String]): Unit = {
+    val config = externalConfig.copy(
+      host = host,
+      port = port.getOrElse(externalConfig.port),
+      password = password.map(_.toCharArray).getOrElse(externalConfig.password)
+    )
+    managers.getOrElseUpdate((config.host, config.port), {
+      new RemoteConnector(server, config)
+    })
+  }
+
+  def ping(hostPat: String = ".*", port: Int = 0): Unit = {
+    for ((_, connector) <- matchingManagers(hostPat, port)) {
+      connector.ping()
+    }
+  }
+
+  def reconnect(hostPat: String, port: Int = 0): Unit = {
+    for ((key, connector) <- matchingManagers(hostPat, port.toInt)) {
+      connector.reconnect()
+      managers.remove(key)
+    }
+  }
+
+  def drop(hostPat: String, port: Int = 0): Unit = {
+    for ((key, connector) <- matchingManagers(hostPat, port.toInt)) {
+      connector.stop()
+      managers.remove(key)
+    }
+  }
+
+  private def matchingManagers(hostPat: String, port: Int): Seq[((String, Int), RemoteConnector)] = {
+    val hostRegex = hostPat.r
+    for {
+      ((h, p), connector) <- managers.toSeq
+      if hostRegex.unapplySeq(h).isDefined
+      if port == 0 || port == p
+    } yield {
+      ((h, p), connector)
+    }
+  }
+}
+
+class RemoteConnector(server: LocalServer, config: ServerConfig) extends Logging {
+
+  implicit val timeout = 30.seconds
+  val reconnectDelay = 10.seconds
+  val srcId = s"${config.host}:${config.port}"
+
+  class ServerProxy(stopped: Send[Unit]) extends IServer {
+    val name = server.name
+    val doc = server.doc
+    val settings = server.settings
+
+    private var cxn: Connection = _
+    private var messageFunc: (Long, Packet) => Unit = _
+
+    def connected(cxn: Connection): Unit = {
+      this.cxn = cxn
+      messageFunc = (target: Long, pkt: Packet) => {
+        val msg = Request(target, pkt.context, pkt.records)
+        try {
+          cxn.sendMessage(msg)
+        } catch {
+          case e: Exception =>
+            log.error(s"$srcId: error while sending message", e)
+        }
+      }
+    }
+    def handleRequest(packet: Packet): Future[Packet] = {
+      server.request(srcId, packet, messageFunc)
+    }
+    def expire(context: Context): Unit = server.expireContext(srcId, context)
+    def stop(): Unit = {
+      server.expireAll(srcId)
+      stopped.send(())
+    }
+  }
+
+  @volatile private var connected = false
+  def isConnected = connected
+
+  sealed trait Msg
+  case object Ping extends Msg
+  case object Reconnect extends Msg
+  case object Stop extends Msg
+
+  private val ctrl = Chan[Msg](1)
+
+  private val runFuture = go {
+    var done = false
+    while (!done) {
+      log.info(s"$srcId: connecting...")
+      val disconnected = Chan[Unit](1)
+      val server = new ServerProxy(disconnected)
+
+      val cxn: Connection = try {
+        val cxn = Server.start(server, config)
+        connected = true
+        log.info(s"$srcId: connected")
+        cxn
+      } catch {
+        case e: Exception =>
+          log.error(s"$srcId: failed to connect", e)
+          null
+      }
+
+      def doClose(): Unit = {
+        try {
+          cxn.close()
+        } catch {
+          case e: Exception =>
+            log.error(s"$srcId: error during connection close", e)
+        }
+      }
+
+      while (connected) {
+        select(
+          disconnected.onRecv { _ =>
+            log.info(s"$srcId: connection lost; will reconnect after $reconnectDelay")
+            connected = false
+          },
+          ctrl.onRecv {
+            case Ping =>
+              log.info(s"$srcId: ping")
+              val mgr = new ManagerServerProxy(cxn)
+              mgr.echo(Str("ping")).onFailure {
+                case e: Exception =>
+                  log.error(s"$srcId: error during ping", e)
+              }
+
+            case Reconnect =>
+              doClose()
+              log.info(s"$srcId: will reconnect after $reconnectDelay")
+              connected = false
+
+            case Stop =>
+              doClose()
+              log.info(s"$srcId: stopped")
+              connected = false
+              done = true
+          }
+        )
+      }
+
+      if (!done) {
+        select(
+          Time.after(reconnectDelay).onRecv { _ => },
+          ctrl.onRecv {
+            case Ping | Reconnect =>
+            case Stop => done = true
+          }
+        )
+      }
+    }
+  }
+
+  def ping(): Unit = {
+    ctrl.send(Ping)
+  }
+
+  def reconnect(): Unit = {
+    ctrl.send(Reconnect)
+  }
+
+  def stop(): Future[Unit] = {
+    ctrl.send(Stop)
+    runFuture
+  }
+}

--- a/src/main/scala/org/labrad/manager/auth/AuthServer.scala
+++ b/src/main/scala/org/labrad/manager/auth/AuthServer.scala
@@ -1,0 +1,219 @@
+package org.labrad.manager.auth
+
+import org.labrad._
+import org.labrad.annotations._
+import org.labrad.data._
+import org.labrad.errors._
+import org.labrad.manager.{Hub, LocalServer, MultiheadServer}
+import org.labrad.registry.RegistryStore
+import org.labrad.types._
+import org.labrad.util.{AsyncSemaphore, Logging}
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class AuthServer(
+  val id: Long,
+  val name: String,
+  hub: Hub,
+  auth: AuthStore,
+  registry: RegistryStore,
+  externalConfig: ServerConfig
+) extends LocalServer with Logging {
+
+  // enforce doing one thing at a time using an async semaphore
+  private val semaphore = new AsyncSemaphore(1)
+
+  private val contexts = mutable.Map.empty[(String, Context), (AuthContext, RequestContext => Data)]
+
+  val doc = "Provides various methods of authenticating users who wish to log in."
+  private val (_settings, bind) = Reflect.makeHandler[AuthContext]
+
+  val settings = _settings
+
+  // start multi-headed connections to other managers
+  private val multihead = new MultiheadServer(name, registry, this, externalConfig)
+
+  def expireContext(src: String, ctx: Context)(implicit timeout: Duration): Future[Long] = semaphore.map {
+    expire(if (contexts.contains((src, ctx))) Seq((src, ctx)) else Seq())
+  }
+
+  def expireAll(src: String, high: Long)(implicit timeout: Duration): Future[Long] = semaphore.map {
+    expire(contexts.keys.filter { case (s, ctx) => s == src && ctx.high == high }.toSeq)
+  }
+
+  def expireAll(src: String)(implicit timeout: Duration): Future[Unit] = semaphore.map {
+    expire(contexts.keys.filter { case (s, _) => s == src }.toSeq)
+  }
+
+  private def expire(ctxs: Seq[(String, Context)]): Long = ctxs match {
+    case Seq() => 0L
+    case _ =>
+      log.debug(s"expiring contexts: ${ctxs.mkString(",")}")
+      contexts --= ctxs
+      1L
+  }
+
+  def message(src: String, packet: Packet): Unit = {}
+
+  def request(src: String, packet: Packet, messageFunc: (Long, Packet) => Unit)(implicit timeout: Duration): Future[Packet] = semaphore.map {
+    // TODO: handle timeout
+    val response = Server.handle(packet, includeStackTrace = false) { req =>
+      val (_, handler) = contexts.getOrElseUpdate((src, req.context), {
+        val regCtx = new AuthContext(src, req.context, messageFunc)
+        val handler = bind(regCtx)
+        (regCtx, handler)
+      })
+      handler(req)
+    }
+    response
+  }
+
+  // contains context-specific state and settings
+  class AuthContext(src: String, context: Context, messageFunc: (Long, Packet) => Unit) {
+
+    @Setting(id=101,
+             name="auth_methods",
+             doc="Get a list of supported authentication methods")
+    def authMethods(): Seq[String] = {
+      auth.oauthClientInfo match {
+        case None => Seq("username+password")
+        case Some(_) => Seq("username+password", "oauth_token")
+      }
+    }
+
+    @Setting(id=102,
+             name="auth_info",
+             doc="Get info needed for various auth methods")
+    def authInfo(method: String): Data = {
+      method match {
+        case "username+password" =>
+          (("credential_tag", "(ss)")).toData
+
+        case "oauth_token" =>
+          val clientInfo = auth.oauthClientInfo.getOrElse {
+            sys.error("OAuth authentication is not configured")
+          }
+          (("credential_tag", "s"),
+           ("client_id", clientInfo.clientId),
+           ("client_secret", clientInfo.clientSecret)).toData
+
+        case method =>
+          sys.error(s"Unkown authentication method: $method")
+      }
+    }
+
+    @Setting(id=103,
+             name="authenticate",
+             doc="Check password for the given user")
+    def authenticateUser(method: String, credentials: Data): String = {
+      method match {
+        case "username+password" =>
+          val (username, password) = credentials.get[(String, String)]
+          if (!auth.checkUserPassword(username, password)) {
+            sys.error("invalid username or password")
+          }
+          username
+
+        case "oauth_token" =>
+          val idTokenString = credentials.get[String]
+          auth.checkUserOAuth(idTokenString).getOrElse {
+            sys.error("invalid oauth token")
+          }
+
+        case method =>
+          sys.error(s"Unknown authentication method: $method")
+      }
+    }
+
+    // username/password management
+
+    private def requireAdmin(ctx: RequestContext, operation: String): Unit = {
+      require(src == "", s"Must connect to manager where Auth server is running locally to $operation.")
+      val requester = hub.username(ctx.source)
+      require(requester == "" || auth.isAdmin(requester), s"Must be admin to $operation.")
+    }
+
+    @Setting(id=200, name="users", doc="Get list of users and their admin status.")
+    def usersList(): Seq[(String, Boolean)] = {
+      auth.listUsers()
+    }
+
+    @Setting(id=201, name="users_add",
+        doc="""Add a user with the given name, admin status, and optional password.
+            |
+            |If no password is given, then only OAuth login will be supported for this user.""")
+    def usersAdd(ctx: RequestContext, username: String, isAdmin: Boolean, passwordOpt: Option[String]): Unit = {
+      requireAdmin(ctx, "add user")
+      auth.addUser(username, isAdmin, passwordOpt)
+    }
+
+    @Setting(id=202, name="users_change_password", doc="Change a user password")
+    def usersChangePassword(ctx: RequestContext, username: String, oldPassword: Option[String], newPassword: Option[String]): Unit = {
+      val requester = hub.username(ctx.source)
+      if (requester != username) {
+        requireAdmin(ctx, "change password")
+      }
+      auth.changePassword(username, oldPassword, newPassword)
+    }
+
+    @Setting(id=203, name="users_set_admin", doc="Change admin status of a user")
+    def usersSetAdmin(ctx: RequestContext, username: String, isAdmin: Boolean): Unit = {
+      requireAdmin(ctx, "change admin status")
+      auth.setAdmin(username, isAdmin)
+    }
+
+    @Setting(id=204, name="users_remove", doc="Remove the given user")
+    def usersRemove(ctx: RequestContext, username: String): Unit = {
+      requireAdmin(ctx, "remove user")
+      auth.removeUser(username)
+    }
+
+
+    // remote managers
+
+    @Setting(id=1000,
+             name="managers",
+             doc="Get a list of managers we are connecting to as an external registry")
+    def managersList(): Seq[(String, Int, Boolean)] = {
+      multihead.list()
+    }
+
+    @Setting(id=1001,
+             name="managers_refresh",
+             doc="Refresh the list of managers from the registry.")
+    def managersRefresh(): Unit = {
+      multihead.refresh()
+    }
+
+    @Setting(id=1002,
+             name="managers_add",
+             doc="Add a new manager to connect to as an external registry")
+    def managersAdd(host: String, port: Option[Int], password: Option[String]): Unit = {
+      multihead.add(host, port, password)
+    }
+
+    @Setting(id=1003,
+             name="managers_ping",
+             doc="Send a network ping to all external managers")
+    def managersPing(hostPat: String = ".*", port: Int = 0): Unit = {
+      multihead.ping(hostPat, port)
+    }
+
+    @Setting(id=1004,
+             name="managers_reconnect",
+             doc="Disconnect from matching managers and reconnect")
+    def managersReconnect(hostPat: String, port: Int = 0): Unit = {
+      multihead.reconnect(hostPat, port)
+    }
+
+    @Setting(id=1005,
+             name="managers_drop",
+             doc="Disconnect from matching managers and do not reconnect")
+    def managersDrop(hostPat: String, port: Int = 0): Unit = {
+      multihead.drop(hostPat, port)
+    }
+  }
+}
+

--- a/src/main/scala/org/labrad/manager/auth/AuthStore.scala
+++ b/src/main/scala/org/labrad/manager/auth/AuthStore.scala
@@ -1,0 +1,186 @@
+package org.labrad.manager.auth
+
+import anorm._
+import anorm.SqlParser._
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.http.javanet.NetHttpTransport
+import java.io.{ByteArrayInputStream, File}
+import java.sql.{Connection, DriverManager}
+import org.labrad.data._
+import org.labrad.errors._
+import org.labrad.registry.RegistryStore
+import org.labrad.util.Logging
+import org.mindrot.jbcrypt.BCrypt
+import scala.collection.JavaConverters._
+
+case class OAuthClientInfo(clientId: String, clientSecret: String)
+
+trait AuthStore {
+  val oauthClientInfo: Option[OAuthClientInfo]
+
+  def listUsers(): Seq[(String, Boolean)]
+  def addUser(username: String, isAdmin: Boolean, passwordOpt: Option[String]): Unit
+  def changePassword(username: String, oldPassword: Option[String], newPassword: Option[String]): Unit
+  def checkUser(username: String): Boolean
+  def checkUserPassword(username: String, password: String): Boolean
+  def checkUserOAuth(idTokenString: String): Option[String]
+  def isAdmin(username: String): Boolean
+  def setAdmin(username: String, isAdmin: Boolean): Unit
+  def removeUser(username: String): Unit
+}
+
+object AuthStore {
+  def apply(file: File, oauthClientInfo: Option[OAuthClientInfo]): AuthStore = {
+    Class.forName("org.sqlite.JDBC")
+    val url = s"jdbc:sqlite:${file.getAbsolutePath}"
+    implicit val conn = DriverManager.getConnection(url)
+
+    // set up registry schema if it does not already exist
+    SQL"""
+      CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        is_admin BOOLEAN NOT NULL,
+        password_hash TEXT,
+
+        UNIQUE (name)
+      )
+    """.execute()
+
+    SQL"""
+      CREATE INDEX IF NOT EXISTS idx_list_users ON users(name)
+    """.execute()
+
+    new AuthStoreImpl(conn, oauthClientInfo)
+  }
+}
+
+class AuthStoreImpl(
+  cxn: Connection,
+  val oauthClientInfo: Option[OAuthClientInfo]
+) extends AuthStore with Logging {
+
+  private implicit val connection = cxn
+
+  def listUsers(): Seq[(String, Boolean)] = {
+    // get name and is_admin; handle SQLite storing bool as int
+    val parser = (get[String]("name") ~ get[Int]("is_admin")) map {
+      case name ~ isAdmin => (name, isAdmin != 0)
+    }
+    SQL"""
+      SELECT name, is_admin FROM users
+    """.as(parser.*)
+  }
+
+  def addUser(username: String, isAdmin: Boolean, passwordOpt: Option[String]): Unit = {
+    require(username.nonEmpty, "Cannot add user with empty username")
+    passwordOpt match {
+      case None | Some("") =>
+        SQL"""
+          INSERT INTO users(name, is_admin) VALUES ($username, $isAdmin)
+        """.executeInsert()
+
+      case Some(password) =>
+        val hashed = BCrypt.hashpw(password, BCrypt.gensalt())
+        SQL"""
+          INSERT INTO users(name, password_hash, is_admin) VALUES ($username, $hashed, $isAdmin)
+        """.executeInsert()
+    }
+  }
+
+  def changePassword(
+    username: String,
+    oldPasswordOpt: Option[String],
+    newPasswordOpt: Option[String]
+  ): Unit = {
+    val oldHashedOpt = SQL"""
+      SELECT password_hash FROM users WHERE name = $username
+    """.as(get[Option[String]]("password_hash").singleOpt)
+       .getOrElse { sys.error(s"username $username does not exist") }
+
+    // Check that provided oldPassword matches stored hash, if there is one.
+    for (oldHashed <- oldHashedOpt) {
+      val oldPassword = oldPasswordOpt.getOrElse { sys.error(s"incorrect password") }
+      if (!BCrypt.checkpw(oldPassword, oldHashed)) sys.error(s"incorrect password")
+    }
+
+    // Set or clear the password.
+    newPasswordOpt match {
+      case None | Some("") =>
+        SQL"""
+          UPDATE users SET password_hash = NULL WHERE name = $username
+        """.executeUpdate()
+
+      case Some(newPassword) =>
+        val newHashed = BCrypt.hashpw(newPassword, BCrypt.gensalt())
+        SQL"""
+          UPDATE users SET password_hash = $newHashed WHERE name = $username
+        """.executeUpdate()
+    }
+  }
+
+  def checkUser(username: String): Boolean = {
+    val n = SQL"""
+      SELECT count(*) AS n FROM users WHERE name = $username
+    """.as(get[Int]("n").single)
+    n > 0
+  }
+
+  def checkUserPassword(username: String, password: String): Boolean = {
+    val hashed = SQL"""
+      SELECT password_hash FROM users WHERE name = $username AND password_hash IS NOT NULL
+    """.as(get[String]("password_hash").singleOpt)
+       .getOrElse { sys.error(s"username $username does not exist or has no password") }
+
+    BCrypt.checkpw(password, hashed)
+  }
+
+  def isAdmin(username: String): Boolean = {
+    SQL"""
+      SELECT is_admin FROM users WHERE name = $username
+    """.as(get[Int]("is_admin").singleOpt) // SQLite stores bools as ints
+       .map(_ != 0)
+       .getOrElse { sys.error(s"username $username does not exist") }
+  }
+
+  def setAdmin(username: String, isAdmin: Boolean): Unit = {
+    val nRows = SQL"""
+      UPDATE users SET is_admin = $isAdmin WHERE name = $username
+    """.executeUpdate()
+    if (nRows == 0) sys.error(s"username $username does not exist")
+  }
+
+  def removeUser(username: String): Unit = {
+    SQL" DELETE FROM users WHERE name = $username ".execute()
+  }
+
+  def checkUserOAuth(idTokenString: String): Option[String] = {
+    val clientInfo = oauthClientInfo.getOrElse {
+      sys.error("OAuth Client ID not configured")
+    }
+    val username = try {
+      val transport = new NetHttpTransport()
+      val jsonFactory = JacksonFactory.getDefaultInstance()
+      val verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
+          .setAudience(Seq(clientInfo.clientId).asJava)
+          .setIssuer("https://accounts.google.com")
+          .build()
+
+      val token = GoogleIdToken.parse(jsonFactory, idTokenString)
+      if (token == null) throw LabradException(3, "Invalid id token")
+
+      val idToken = verifier.verify(idTokenString)
+      if (idToken == null) throw LabradException(3, "Invalid id token")
+
+      idToken.getPayload.getEmail
+    } catch {
+      case e: Exception =>
+        log.error("error validating id token", e)
+        throw e
+    }
+    if (checkUser(username)) Some(username) else None
+  }
+}
+

--- a/src/main/scala/org/labrad/manager/auth/package.scala
+++ b/src/main/scala/org/labrad/manager/auth/package.scala
@@ -1,0 +1,8 @@
+package org.labrad.manager.auth
+
+object Authenticator {
+  val NAME = "Auth"
+  val METHODS_SETTING_ID = 101
+  val INFO_SETTING_ID = 102
+  val AUTH_SETTING_ID = 103
+}

--- a/src/main/scala/org/labrad/registry/Registry.scala
+++ b/src/main/scala/org/labrad/registry/Registry.scala
@@ -6,7 +6,7 @@ import org.labrad.concurrent.{Chan, Send, Time}
 import org.labrad.concurrent.Go._
 import org.labrad.data._
 import org.labrad.errors._
-import org.labrad.manager.{Hub, ServerActor, StatsTracker}
+import org.labrad.manager.{LocalServer, MultiheadServer, RemoteConnector, ServerActor}
 import org.labrad.types._
 import org.labrad.util.{AsyncSemaphore, Logging}
 import scala.collection.mutable
@@ -68,167 +68,22 @@ object Registry {
   val NAME = "Registry"
 }
 
-class RegistryActor(registry: Registry, hub: Hub) extends ServerActor {
-  val srcId = ""
-  private val messageFunc = (target: Long, pkt: Packet) => hub.message(target, pkt)
-
-  def message(packet: Packet): Unit = registry.message(srcId, packet)
-  def request(packet: Packet)(implicit timeout: Duration): Future[Packet] = {
-    registry.request(srcId, packet, messageFunc)
-  }
-
-  def expireContext(ctx: Context)(implicit timeout: Duration): Future[Long] = registry.expireContext(srcId, ctx)
-  def expireAll(high: Long)(implicit timeout: Duration): Future[Long] = registry.expireAll(srcId, high)
-
-  def close(): Unit = {}
-}
-
-class RegistryConnector(registry: Registry, config: ServerConfig) extends Logging {
-
-  implicit val timeout = 30.seconds
-  val reconnectDelay = 10.seconds
-  val srcId = s"${config.host}:${config.port}"
-
-  class RegistryServer(stopped: Send[Unit]) extends IServer {
-    val name = registry.name
-    val doc = registry.doc
-    val settings = registry.settings
-
-    private var cxn: Connection = _
-    private var messageFunc: (Long, Packet) => Unit = _
-
-    def connected(cxn: Connection): Unit = {
-      this.cxn = cxn
-      messageFunc = (target: Long, pkt: Packet) => {
-        val msg = Request(target, pkt.context, pkt.records)
-        try {
-          cxn.sendMessage(msg)
-        } catch {
-          case e: Exception =>
-            log.error(s"$srcId: error while sending message", e)
-        }
-      }
-    }
-    def handleRequest(packet: Packet): Future[Packet] = {
-      registry.request(srcId, packet, messageFunc)
-    }
-    def expire(context: Context): Unit = registry.expireContext(srcId, context)
-    def stop(): Unit = {
-      registry.expireAll(srcId)
-      stopped.send(())
-    }
-  }
-
-  @volatile private var connected = false
-  def isConnected = connected
-
-  sealed trait Msg
-  case object Ping extends Msg
-  case object Reconnect extends Msg
-  case object Stop extends Msg
-
-  private val ctrl = Chan[Msg](1)
-
-  private val runFuture = go {
-    var done = false
-    while (!done) {
-      log.info(s"$srcId: connecting...")
-      val disconnected = Chan[Unit](1)
-      val server = new RegistryServer(disconnected)
-
-      val cxn: Connection = try {
-        val cxn = Server.start(server, config)
-        connected = true
-        log.info(s"$srcId: connected")
-        cxn
-      } catch {
-        case e: Exception =>
-          log.error(s"$srcId: failed to connect", e)
-          null
-      }
-
-      def doClose(): Unit = {
-        try {
-          cxn.close()
-        } catch {
-          case e: Exception =>
-            log.error(s"$srcId: error during connection close", e)
-        }
-      }
-
-      while (connected) {
-        select(
-          disconnected.onRecv { _ =>
-            log.info(s"$srcId: connection lost; will reconnect after $reconnectDelay")
-            connected = false
-          },
-          ctrl.onRecv {
-            case Ping =>
-              log.info(s"$srcId: ping")
-              val mgr = new ManagerServerProxy(cxn)
-              mgr.echo(Str("ping")).onFailure {
-                case e: Exception =>
-                  log.error(s"$srcId: error during ping", e)
-              }
-
-            case Reconnect =>
-              doClose()
-              log.info(s"$srcId: will reconnect after $reconnectDelay")
-              connected = false
-
-            case Stop =>
-              doClose()
-              log.info(s"$srcId: stopped")
-              connected = false
-              done = true
-          }
-        )
-      }
-
-      if (!done) {
-        select(
-          Time.after(reconnectDelay).onRecv { _ => },
-          ctrl.onRecv {
-            case Ping | Reconnect =>
-            case Stop => done = true
-          }
-        )
-      }
-    }
-  }
-
-  def ping(): Unit = {
-    ctrl.send(Ping)
-  }
-
-  def reconnect(): Unit = {
-    ctrl.send(Reconnect)
-  }
-
-  def stop(): Future[Unit] = {
-    ctrl.send(Stop)
-    runFuture
-  }
-}
-
-
-class Registry(id: Long, val name: String, store: RegistryStore, hub: Hub, tracker: StatsTracker, externalConfig: ServerConfig)
-extends Logging {
+class Registry(val id: Long, val name: String, store: RegistryStore, externalConfig: ServerConfig)
+extends LocalServer with Logging {
 
   // enforce doing one thing at a time using an async semaphore
   private val semaphore = new AsyncSemaphore(1)
 
   type Src = String
   private val contexts = mutable.Map.empty[(Src, Context), (RegistryContext, RequestContext => Data)]
-  private val managers = mutable.Map.empty[(String, Int), RegistryConnector]
 
   val doc = "Provides a file system-like heirarchical storage of chunks of labrad data. Also allows clients to register for notifications when directories or keys are added or changed."
   private val (_settings, bind) = Reflect.makeHandler[RegistryContext]
 
   val settings = _settings
 
-  // send info about this server and its settings to the manager
-  hub.setServerInfo(ServerInfo(id, name, doc, settings))
+  // start multi-headed connections to other managers
+  private val multihead = new MultiheadServer(name, store, this, externalConfig)
 
   def expireContext(src: Src, ctx: Context)(implicit timeout: Duration): Future[Long] = semaphore.map {
     expire(if (contexts.contains((src, ctx))) Seq((src, ctx)) else Seq())
@@ -250,13 +105,10 @@ extends Logging {
       1L
   }
 
-  def message(src: Src, packet: Packet): Unit = {
-    tracker.msgRecv(id)
-  }
+  def message(src: Src, packet: Packet): Unit = {}
 
   def request(src: Src, packet: Packet, messageFunc: (Long, Packet) => Unit)(implicit timeout: Duration): Future[Packet] = semaphore.map {
     // TODO: handle timeout
-    tracker.serverReq(id)
     val response = Server.handle(packet, includeStackTrace = false) { req =>
       val (_, handler) = contexts.getOrElseUpdate((src, req.context), {
         val regCtx = new RegistryContext(src, req.context, messageFunc)
@@ -265,7 +117,6 @@ extends Logging {
       })
       handler(req)
     }
-    tracker.serverRep(id)
     response
   }
 
@@ -280,36 +131,6 @@ extends Logging {
 
   // tell the backend to call us when changes are made
   store.notifyOnChange(notifyContexts)
-
-  private def refreshManagers(): Unit = {
-    // load the list of managers from the registry
-    var dir = store.root
-    dir = store.child(dir, "Servers", create = true)
-    dir = store.child(dir, "Registry", create = true)
-    dir = store.child(dir, "Multihead", create = true)
-    val default = DataBuilder("*(sws)").array(0).result()
-    val result = store.getValue(dir, "Managers", default = Some((true, default)))
-    val configs = result.get[Seq[(String, Long, String)]].map {
-      case (host, port, pw) =>
-        externalConfig.copy(
-          host = host,
-          port = if (port != 0) port.toInt else externalConfig.port,
-          password = if (pw != "") pw.toCharArray else externalConfig.password
-        )
-    }
-    val urls = configs.map(c => s"${c.host}:${c.port}")
-    log.info(s"managers in registry: ${urls.mkString(", ")}")
-
-    // connect to any managers we are not already connected to
-    for (config <- configs) {
-      managers.getOrElseUpdate((config.host, config.port), {
-        new RegistryConnector(Registry.this, config)
-      })
-    }
-  }
-
-  // connect to managers that are stored in the registry
-  refreshManagers()
 
   // contains context-specific state and settings
   class RegistryContext(src: Src, context: Context, messageFunc: (Long, Packet) => Unit) {
@@ -440,70 +261,42 @@ extends Logging {
              name="Managers",
              doc="Get a list of managers we are connecting to as an external registry")
     def managersList(): Seq[(String, Int, Boolean)] = {
-      managers.toSeq.map { case ((host, port), reg) =>
-        (host, port, reg.isConnected)
-      }.sorted
+      multihead.list()
     }
 
     @Setting(id=1001,
              name="Managers Refresh",
              doc="Refresh the list of managers from the registry.")
     def managersRefresh(): Unit = {
-      refreshManagers()
+      multihead.refresh()
     }
 
     @Setting(id=1002,
              name="Managers Add",
              doc="Add a new manager to connect to as an external registry")
     def managersAdd(host: String, port: Option[Int], password: Option[String]): Unit = {
-      val config = externalConfig.copy(
-        host = host,
-        port = port.getOrElse(externalConfig.port),
-        password = password.map(_.toCharArray).getOrElse(externalConfig.password)
-      )
-      managers.getOrElseUpdate((config.host, config.port), {
-        new RegistryConnector(Registry.this, config)
-      })
+      multihead.add(host, port, password)
     }
 
     @Setting(id=1003,
              name="Managers Ping",
              doc="Send a network ping to all external managers")
     def managersPing(hostPat: String = ".*", port: Int = 0): Unit = {
-      for ((_, reg) <- matchingManagers(hostPat, port)) {
-        reg.ping()
-      }
+      multihead.ping(hostPat, port)
     }
 
     @Setting(id=1004,
              name="Managers Reconnect",
              doc="Disconnect from matching managers and reconnect")
     def managersReconnect(hostPat: String, port: Int = 0): Unit = {
-      for ((key, reg) <- matchingManagers(hostPat, port.toInt)) {
-        reg.reconnect()
-        managers.remove(key)
-      }
+      multihead.reconnect(hostPat, port)
     }
 
     @Setting(id=1005,
              name="Managers Drop",
              doc="Disconnect from matching managers and do not reconnect")
     def managersDrop(hostPat: String, port: Int = 0): Unit = {
-      for ((key, reg) <- matchingManagers(hostPat, port.toInt)) {
-        reg.stop()
-        managers.remove(key)
-      }
-    }
-
-    private def matchingManagers(hostPat: String, port: Int): Seq[((String, Int), RegistryConnector)] = {
-      val hostRegex = hostPat.r
-      for {
-        ((h, p), reg) <- managers.toSeq
-        if hostRegex.unapplySeq(h).isDefined
-        if port == 0 || port == p
-      } yield {
-        ((h, p), reg)
-      }
+      multihead.drop(hostPat, port)
     }
 
     /**

--- a/src/test/scala/org/labrad/ReflectTest.scala
+++ b/src/test/scala/org/labrad/ReflectTest.scala
@@ -359,9 +359,12 @@ class ReflectTest extends FunSuite with Logging {
       def allocateClientId(name: String): Long = 0
       def allocateServerId(name: String): Long = 0
 
+      def getServerId(name: String): Long = 0
+
       def connectClient(id: Long, name: String, handler: ClientActor): Unit = {}
       def connectServer(id: Long, name: String, handler: ServerActor): Unit = {}
 
+      def username(id: Long): String = ""
       def disconnect(id: Long): Unit = {}
       def close(id: Long): Unit = {}
 
@@ -379,6 +382,7 @@ class ReflectTest extends FunSuite with Logging {
       )
       def serverInfo(id: Either[Long, String]): Option[ServerInfo] = None
 
+      def authServerConnected = Future.successful(())
       def registryConnected = Future.successful(())
     }
 

--- a/src/test/scala/org/labrad/TestUtils.scala
+++ b/src/test/scala/org/labrad/TestUtils.scala
@@ -42,7 +42,7 @@ object TestUtils extends {
       val tlsHosts = TlsHostConfig((ssc.certificate, sslCtx))
       val listeners = Seq(port -> tlsPolicy)
 
-      val manager = new CentralNode(password, Some(registryStore), listeners, tlsHosts)
+      val manager = new CentralNode(password, Some(registryStore), None, listeners, tlsHosts)
       try {
         f(ManagerInfo(host, port, password, tlsPolicy, tlsHosts))
       } finally {


### PR DESCRIPTION
Adds a notion of "username" when making a connection to the manager. When logging in with the global password as before, the username is the empty string "". The new "Auth" server allows to manage the list of users and also handles logging them in. This server is implemented as a "multiheaded" server like the registry; it can run in process with the manager and also connect out to other managers that are not running an auth server locally to provide login for them using a single shared list of users.

OAuth login uses the flow for Mobile and Desktop applications as described here: https://developers.google.com/identity/protocols/OAuth2InstalledApp

To use this, the client asks the manager (via the auth server) for the oauth client_id and client_secret of the registered labrad oauth application to be used for login. These are used to launch the login flow by opening a web browser for the user to log in to his google account and authorize the labrad application to see his email address. Upon successfull login and authorization, the user receives an "id_token" that is a cryptographically-signed record of the user's email address. This is passed back to the manager, and the manager then calls google APIs to validate the token and then check that the user's email address is in the list of allowed users.
