### PR TITLE
Be explicit about ExecutionContexts used for different purposes

### DIFF
--- a/src/main/scala/org/labrad/concurrent/ExecutionContexts.scala
+++ b/src/main/scala/org/labrad/concurrent/ExecutionContexts.scala
@@ -1,0 +1,27 @@
+package org.labrad.concurrent
+
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicLong
+import scala.concurrent.{ExecutionContext, Future}
+
+object ExecutionContexts {
+
+  /**
+   * Create an ExecutionContext backed by a cached thread pool.
+   * All threads will be created in a group and named with the given name.
+   */
+  def newCachedThreadExecutionContext(name: String): ExecutionContext = {
+    val threadGroup = new ThreadGroup(name)
+    val threadFactory = new ThreadFactory {
+      val counter = new AtomicLong(0)
+      def newThread(r: Runnable): Thread = {
+        val i = counter.getAndIncrement()
+        val thread = new Thread(threadGroup, r, s"$name$i")
+        thread.setDaemon(true)
+        thread
+      }
+    }
+    val executor = Executors.newCachedThreadPool(threadFactory)
+    ExecutionContext.fromExecutorService(executor)
+  }
+}

--- a/src/main/scala/org/labrad/concurrent/Go.scala
+++ b/src/main/scala/org/labrad/concurrent/Go.scala
@@ -15,22 +15,10 @@ import scala.util.Try
 
 object Go {
 
-  private val threadGroup = new ThreadGroup("Go")
-
-  private val threadFactory = new ThreadFactory {
-    val counter = new AtomicLong(0)
-    def newThread(r: Runnable): Thread = {
-      val i = counter.getAndIncrement()
-      val thread = new Thread(threadGroup, r, s"Go$i")
-      thread.setDaemon(true)
-      thread
-    }
-  }
-
-  private[concurrent] val executor = Executors.newCachedThreadPool(threadFactory)
   private[concurrent] val timer = new Timer("GoTimer", true)
 
-  private val executionContext = ExecutionContext.fromExecutorService(executor)
+  private val executionContext =
+    ExecutionContexts.newCachedThreadExecutionContext("Go")
 
   def go[A](f: => A): Future[A] = {
     Future(f)(executionContext)

--- a/src/main/scala/org/labrad/manager/Hub.scala
+++ b/src/main/scala/org/labrad/manager/Hub.scala
@@ -9,8 +9,7 @@ import org.labrad.registry._
 import org.labrad.types._
 import org.labrad.util._
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
 
 trait Hub {
@@ -47,7 +46,8 @@ object Hub {
   def notFound(id: Long) = Future.failed(new Exception(s"target not found: $id"))
 }
 
-class HubImpl(tracker: StatsTracker, _messager: () => Messager) extends Hub with Logging {
+class HubImpl(tracker: StatsTracker, _messager: () => Messager)(implicit ec: ExecutionContext)
+extends Hub with Logging {
 
   private val allocatedClientIds = mutable.Map.empty[Long, String]
   private val allocatedServerIds = mutable.Map.empty[Long, String]

--- a/src/main/scala/org/labrad/manager/Listener.scala
+++ b/src/main/scala/org/labrad/manager/Listener.scala
@@ -88,12 +88,11 @@ class Listener(
   listeners: Seq[(Int, TlsPolicy)],
   tlsHostConfig: TlsHostConfig,
   authTimeout: Duration,
-  registryTimeout: Duration
+  registryTimeout: Duration,
+  bossGroup: EventLoopGroup,
+  workerGroup: EventLoopGroup,
+  loginGroup: EventLoopGroup
 ) extends Logging {
-
-  val bossGroup = Listener.newBossGroup()
-  val workerGroup = Listener.newWorkerGroup()
-  val loginGroup = Listener.newLoginGroup()
 
   def bootServer(port: Int, tlsPolicy: TlsPolicy): Channel = {
     try {
@@ -145,14 +144,9 @@ class Listener(
   }
 
   private def shutdown(listeners: Seq[Channel]): Unit = {
-    try {
-      for (ch <- listeners) {
-        ch.close()
-        ch.closeFuture.sync()
-      }
-    } finally {
-      workerGroup.shutdownGracefully()
-      bossGroup.shutdownGracefully()
+    for (ch <- listeners) {
+      ch.close()
+      ch.closeFuture.sync()
     }
   }
 }

--- a/src/main/scala/org/labrad/manager/Listener.scala
+++ b/src/main/scala/org/labrad/manager/Listener.scala
@@ -89,8 +89,8 @@ class Listener(
   tlsHostConfig: TlsHostConfig,
   authTimeout: Duration,
   registryTimeout: Duration
-)(implicit ec: ExecutionContext)
-extends Logging {
+) extends Logging {
+
   val bossGroup = Listener.newBossGroup()
   val workerGroup = Listener.newWorkerGroup()
   val loginGroup = Listener.newLoginGroup()

--- a/src/main/scala/org/labrad/manager/LoginHandler.scala
+++ b/src/main/scala/org/labrad/manager/LoginHandler.scala
@@ -72,7 +72,7 @@ class LoginHandler(
   tlsPolicy: TlsPolicy,
   authTimeout: Duration,
   registryTimeout: Duration
-)(implicit ec: ExecutionContext)
+)
 extends SimpleChannelInboundHandler[Packet] with Logging {
 
   override def channelActive(ctx: ChannelHandlerContext): Unit = {

--- a/src/main/scala/org/labrad/manager/Manager.scala
+++ b/src/main/scala/org/labrad/manager/Manager.scala
@@ -82,7 +82,7 @@ class CentralNode(
     val id = hub.allocateServerId(name)
     val registry = new Registry(id, name, regStore, externalConfig)(serversExecutionContext)
     hub.setServerInfo(ServerInfo(registry.id, registry.name, registry.doc, registry.settings))
-    hub.connectServer(id, name, new LocalServerActor(registry, hub, tracker))
+    hub.connectServer(id, name, new LocalServerActor(registry, hub, tracker)(nettyExecutionContext))
   }
 
   for (authStore <- authStoreOpt) {
@@ -98,7 +98,7 @@ class CentralNode(
     }
     val auth = new AuthServer(id, name, hub, authStore, verifierOpt, regStore, externalConfig)(serversExecutionContext)
     hub.setServerInfo(ServerInfo(auth.id, auth.name, auth.doc, auth.settings))
-    hub.connectServer(id, name, new LocalServerActor(auth, hub, tracker))
+    hub.connectServer(id, name, new LocalServerActor(auth, hub, tracker)(nettyExecutionContext))
   }
 
   // start listening for incoming network connections

--- a/src/main/scala/org/labrad/manager/RemoteConnector.scala
+++ b/src/main/scala/org/labrad/manager/RemoteConnector.scala
@@ -10,8 +10,7 @@ import org.labrad.registry.RegistryStore
 import org.labrad.types._
 import org.labrad.util.Logging
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 trait LocalServer {
@@ -27,7 +26,8 @@ trait LocalServer {
   def expireAll(src: String)(implicit timeout: Duration): Future[Unit]
 }
 
-class LocalServerActor(server: LocalServer, hub: Hub, tracker: StatsTracker) extends ServerActor {
+class LocalServerActor(server: LocalServer, hub: Hub, tracker: StatsTracker)(implicit ec: ExecutionContext)
+extends ServerActor {
   val username = ""// Local servers running in manager process act like global user
   val srcId = ""
   private val messageFunc = (target: Long, pkt: Packet) => hub.message(target, pkt)
@@ -52,7 +52,8 @@ class LocalServerActor(server: LocalServer, hub: Hub, tracker: StatsTracker) ext
   def close(): Unit = {}
 }
 
-class MultiheadServer(name: String, registry: RegistryStore, server: LocalServer, externalConfig: ServerConfig) extends Logging {
+class MultiheadServer(name: String, registry: RegistryStore, server: LocalServer, externalConfig: ServerConfig)
+                     (implicit ec: ExecutionContext) extends Logging {
   private val managers = mutable.Map.empty[(String, Int), RemoteConnector]
 
   // connect to managers that are stored in the registry
@@ -136,7 +137,7 @@ class MultiheadServer(name: String, registry: RegistryStore, server: LocalServer
   }
 }
 
-class RemoteConnector(server: LocalServer, config: ServerConfig) extends Logging {
+class RemoteConnector(server: LocalServer, config: ServerConfig)(implicit ec: ExecutionContext) extends Logging {
 
   implicit val timeout = 30.seconds
   val reconnectDelay = 10.seconds

--- a/src/main/scala/org/labrad/manager/RemoteConnector.scala
+++ b/src/main/scala/org/labrad/manager/RemoteConnector.scala
@@ -152,7 +152,7 @@ class RemoteConnector(server: LocalServer, config: ServerConfig)(implicit ec: Ex
     private var cxn: Connection = _
     private var messageFunc: (Long, Packet) => Unit = _
 
-    def connected(cxn: Connection): Unit = {
+    def connected(cxn: Connection, ec: ExecutionContext): Unit = {
       this.cxn = cxn
       messageFunc = (target: Long, pkt: Packet) => {
         val msg = Request(target, pkt.context, pkt.records)

--- a/src/main/scala/org/labrad/manager/auth/AuthServer.scala
+++ b/src/main/scala/org/labrad/manager/auth/AuthServer.scala
@@ -9,8 +9,7 @@ import org.labrad.registry.RegistryStore
 import org.labrad.types._
 import org.labrad.util.{AsyncSemaphore, Logging}
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 class AuthServer(
@@ -21,7 +20,7 @@ class AuthServer(
   oauth: Option[OAuthVerifier],
   registry: RegistryStore,
   externalConfig: ServerConfig
-) extends LocalServer with Logging {
+)(implicit ec: ExecutionContext) extends LocalServer with Logging {
 
   val doc = "Provides various methods of authenticating users who wish to log in."
   private val (_settings, bind) = Reflect.makeHandler[AuthServer]
@@ -49,8 +48,8 @@ class AuthServer(
   def message(src: String, packet: Packet): Unit = {}
 
   def request(src: String, packet: Packet, messageFunc: (Long, Packet) => Unit)(implicit timeout: Duration): Future[Packet] = {
-    Server.handleAsync(packet) { req =>
-      Future {
+    Future {
+      Server.handle(packet) { req =>
         handler(req.withValue(srcKey, src))
       }
     }

--- a/src/main/scala/org/labrad/registry/Migrate.scala
+++ b/src/main/scala/org/labrad/registry/Migrate.scala
@@ -8,7 +8,6 @@ import org.labrad.{Client, Password, RegistryServerProxy}
 import org.labrad.data.Data
 import org.labrad.util.Util
 import scala.concurrent.{Await, Future}
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.io.Source
 

--- a/src/main/scala/org/labrad/registry/Registry.scala
+++ b/src/main/scala/org/labrad/registry/Registry.scala
@@ -10,8 +10,7 @@ import org.labrad.manager.{LocalServer, MultiheadServer, RemoteConnector, Server
 import org.labrad.types._
 import org.labrad.util.{AsyncSemaphore, Logging}
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 trait RegistryStore {
@@ -69,6 +68,7 @@ object Registry {
 }
 
 class Registry(val id: Long, val name: String, store: RegistryStore, externalConfig: ServerConfig)
+              (implicit ec: ExecutionContext)
 extends LocalServer with Logging {
 
   // enforce doing one thing at a time using an async semaphore

--- a/src/test/scala/org/labrad/ManagerTest.scala
+++ b/src/test/scala/org/labrad/ManagerTest.scala
@@ -4,7 +4,6 @@ import org.labrad.data._
 import org.scalatest.{FunSuite, Tag}
 import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.time.SpanSugar._
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class ManagerTest extends FunSuite with AsyncAssertions {
 

--- a/src/test/scala/org/labrad/RegistryTest.scala
+++ b/src/test/scala/org/labrad/RegistryTest.scala
@@ -9,7 +9,6 @@ import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.time.SpanSugar._
 import scala.collection._
 import scala.concurrent.{Await, Future}
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 

--- a/src/test/scala/org/labrad/manager/auth/AuthStoreTest.scala
+++ b/src/test/scala/org/labrad/manager/auth/AuthStoreTest.scala
@@ -10,7 +10,6 @@ import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.time.SpanSugar._
 import scala.collection._
 import scala.concurrent.{Await, Future}
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class AuthStoreTest extends FunSuite {
 

--- a/src/test/scala/org/labrad/registry/RemoteStoreTest.scala
+++ b/src/test/scala/org/labrad/registry/RemoteStoreTest.scala
@@ -10,7 +10,6 @@ import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.time.SpanSugar._
 import scala.collection._
 import scala.concurrent.{Await, Future}
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class RemoteStoreTest extends FunSuite with Matchers with AsyncAssertions {
 


### PR DESCRIPTION
`ExecutionContext` instances are used to run blocking code in an asynchronous fashion (by calling the `Future.apply`) and to schedule callbacks on `Futures` (by calling the various methods like `map` or `onComplete` on `Future` instances). Depending on what kind of work we need to do, we may want to use different execution contexts, for example we don't want to run code that could block for a long time on the global execution context because then we may block networking threads from doing useful work. In the past we have been somewhat careless about which execution contexts to use where, and have mostly defaulted to importing an implicit reference to the global context so that it gets used by all the Future apis. Here we try to be a little more careful.

For the manager, we create two different execution contexts: the first is backed by the netty threads which is appropriate for running very short network-related callbacks like routing packets between clients and servers and tracking stats. The second is backed by a growable pool of dedicated worker threads and is appropriate for doing work that may block for longer periods of time; we handle requests to the auth and registry servers on this latter execution context.

For servers, we modify the `Server` class to also use two separate execution contexts, one backed by the netty threads (this already existed in the `executionContext` field in the `Connection` class), and one backed by a poll of dedicated worker threads for handling server requests, as in the manager. I made this configurable so the worker thread pool can be disabled with the `directExecutor` flag on the server config object (inspired by the analogous `directExecutor` method in the [grpc ServerBuilder](http://www.grpc.io/grpc-java/javadoc/io/grpc/ServerBuilder.html#directExecutor--)).

I think this is a big improvement but the code is still not super clear, and there may be some ways to improve things and make it more clear what is running where. Part of the problem is the scala Future api itself, which makes is particularly awkward when you want to run different code in different execution contexts, since you can only have one implicit `ExecutionContext` value in scope at a time.

@kunalq, please let me know what you think. Also, sorry about the size of the PR; the individual commits are self-contained and more reasonably size. I've included them all here because they're all closely related to cleaning up the use of execution contexts.
