### PR TITLE
Add support for using OAuth access token instead of id token.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,8 @@ libraryDependencies ++= Seq(
   "org.bouncycastle" % "bcprov-jdk15on" % "1.52",
   "org.bouncycastle" % "bcpkix-jdk15on" % "1.52",
   "org.mindrot" % "jbcrypt" % "0.3m",
-  "com.google.api-client" % "google-api-client" % "1.19.0"
+  "com.google.api-client" % "google-api-client" % "1.19.0",
+  "com.google.http-client" % "google-http-client" % "1.19.0"
 )
 
 // When running, connect std in and tell manager to stop on EOF (ctrl+D).

--- a/src/main/scala/org/labrad/Connection.scala
+++ b/src/main/scala/org/labrad/Connection.scala
@@ -67,7 +67,8 @@ object Connection {
 
 sealed trait Credential
 case class Password(username: String, password: Array[Char]) extends Credential
-case class OAuthToken(idToken: String) extends Credential
+case class OAuthIdToken(idToken: String) extends Credential
+case class OAuthAccessToken(accessToken: String) extends Credential
 
 /**
  * A client or server connection to the Labrad manager.
@@ -236,9 +237,14 @@ trait Connection {
           val data = ("username+password", (username, new String(password))).toData
           Await.result(sendManagerRequest(Authenticator.AUTH_SETTING_ID, data), timeout)
 
-        case OAuthToken(idToken) =>
+        case OAuthIdToken(idToken) =>
           require(isSecureOrLocal, "oauth_token requires secure connection")
           val data = ("oauth_token", idToken).toData
+          Await.result(sendManagerRequest(Authenticator.AUTH_SETTING_ID, data), timeout)
+
+        case OAuthAccessToken(accessToken) =>
+          require(isSecureOrLocal, "oauth_access_token requires secure connection")
+          val data = ("oauth_access_token", accessToken).toData
           Await.result(sendManagerRequest(Authenticator.AUTH_SETTING_ID, data), timeout)
       }
 

--- a/src/main/scala/org/labrad/manager/auth/OAuth.scala
+++ b/src/main/scala/org/labrad/manager/auth/OAuth.scala
@@ -2,10 +2,14 @@ package org.labrad.manager.auth
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
+import com.google.api.client.json.{GenericJson, JsonObjectParser}
 import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.http.{GenericUrl, HttpHeaders, HttpRequest, HttpRequestInitializer}
 import com.google.api.client.http.javanet.NetHttpTransport
+import com.google.api.client.util.Key
 import org.labrad.errors.LabradException
 import org.labrad.util.Logging
+import scala.annotation.meta.field
 import scala.collection.JavaConverters._
 
 sealed trait OAuthClientType
@@ -16,27 +20,68 @@ object OAuthClientType {
 
 case class OAuthClientInfo(clientId: String, clientSecret: String)
 
+/**
+ * To authorize access to labrad, users must provide an access token which we
+ * use to call an oauth endpoint to get user info, in particular the user's
+ * email address. Documentation about the userinfo endpoint can be found in the
+ * OpenID Connect standard:
+ * http://openid.net/specs/openid-connect-core-1_0.html#UserInfo.
+ */
+object UserInfo {
+  val URL = new GenericUrl("https://www.googleapis.com/oauth2/v1/userinfo")
+}
+
+/**
+ * Class to hold user information as returned by the userinfo endpoint.
+ * We only care about the email and verified_email fields of the response; the
+ * corresponding fields here are annotated with @Key which is used by the
+ * google http client json infrastructure when parsing the response to know
+ * which fields to extract.
+ */
+class UserInfo extends GenericJson {
+  @(Key @field) var email: String = ""
+  @(Key @field)("verified_email") var verifiedEmail: Boolean = false
+}
+
 class OAuthVerifier(val clients: Map[OAuthClientType, OAuthClientInfo]) extends Logging {
-  def verifyToken(idTokenString: String): String = {
-    try {
-      val transport = new NetHttpTransport()
-      val jsonFactory = JacksonFactory.getDefaultInstance()
-      val verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
-          .setAudience(clients.values.toSeq.map(_.clientId).asJava)
-          .setIssuer("https://accounts.google.com")
-          .build()
 
-      val token = GoogleIdToken.parse(jsonFactory, idTokenString)
-      if (token == null) throw LabradException(3, "Invalid id token")
-
-      val idToken = verifier.verify(idTokenString)
-      if (idToken == null) throw LabradException(3, "Invalid id token")
-
-      idToken.getPayload.getEmail
-    } catch {
-      case e: Exception =>
-        log.error("error validating id token", e)
-        throw e
+  private val transport = new NetHttpTransport()
+  private val jsonFactory = JacksonFactory.getDefaultInstance()
+  private val requestFactory = transport.createRequestFactory(
+    new HttpRequestInitializer() {
+      override def initialize(request: HttpRequest): Unit = {
+        request.setParser(new JsonObjectParser(jsonFactory))
+      }
     }
+  )
+
+  def verifyIdToken(idTokenString: String): String = {
+    val verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
+        .setAudience(clients.values.toSeq.map(_.clientId).asJava)
+        .setIssuer("https://accounts.google.com")
+        .build()
+
+    val token = GoogleIdToken.parse(jsonFactory, idTokenString)
+    if (token == null) throw LabradException(3, "Invalid id token")
+
+    val idToken = verifier.verify(idTokenString)
+    if (idToken == null) throw LabradException(3, "Invalid id token")
+
+    val payload = idToken.getPayload
+    if (!payload.getEmailVerified) throw LabradException(3, "Email not verified")
+    payload.getEmail
+  }
+
+  def verifyAccessToken(accessTokenString: String): String = {
+    val request = requestFactory.buildGetRequest(UserInfo.URL)
+    request.setHeaders(new HttpHeaders().setAuthorization(s"Bearer $accessTokenString"))
+
+    val response = request.execute()
+    require((200 to 299).contains(response.getStatusCode),
+      s"Failed to get userinfo: ${response.getStatusCode} ${response.getStatusMessage}")
+
+    val userInfo = response.parseAs(classOf[UserInfo])
+    if (!userInfo.verifiedEmail) throw LabradException(3, "Email not verified")
+    userInfo.email
   }
 }


### PR DESCRIPTION
Previously we used an id token for oauth login, which is a signed blob that includes the user's email address. The manager must call out to an external server to verify this token and extract the email address. The problem with this is that the id token is rather large and usually has a short lifetime.

An access token is a more conventional way to use OAuth; it is a token that the client passes to a server to let the server make API requests on the client's behalf. Here, the manager makes a userinfo requests to get the user's email address and compare it against our db. This is no more work than verifying the id token, but access tokens are smaller and tend to have longer lifetimes, so user's will not need to reauthenticate as often.

@kunalq 
