### PR TITLE
Use scala's global ExecutionContext instead of one backed by netty

### DIFF
--- a/src/main/scala/org/labrad/Client.scala
+++ b/src/main/scala/org/labrad/Client.scala
@@ -14,7 +14,7 @@ class Client(
   val tlsCerts: Map[String, File] = Map(),
   val workerGroup: EventLoopGroup = Connection.defaultWorkerGroup
 )(
-  implicit val executionContext: ExecutionContext = Connection.defaultExecutionContext
+  implicit val executionContext: ExecutionContext = ExecutionContext.global
 ) extends Connection {
   protected def loginData = Cluster(UInt(Client.PROTOCOL_VERSION), Str(name))
 }

--- a/src/main/scala/org/labrad/Connection.scala
+++ b/src/main/scala/org/labrad/Connection.scala
@@ -60,9 +60,6 @@ object Connection {
     }
     group
   }
-
-  lazy val defaultExecutionContext =
-    ExecutionContext.fromExecutor(defaultWorkerGroup)
 }
 
 sealed trait Credential

--- a/src/main/scala/org/labrad/ServerConnection.scala
+++ b/src/main/scala/org/labrad/ServerConnection.scala
@@ -19,7 +19,7 @@ class ServerConnection(
   handler: Packet => Future[Packet],
   val workerGroup: EventLoopGroup = Connection.defaultWorkerGroup
 )(
-  implicit val executionContext: ExecutionContext = Connection.defaultExecutionContext
+  implicit val executionContext: ExecutionContext = ExecutionContext.global
 ) extends Connection with Logging {
 
   protected def loginData = Cluster(

--- a/src/main/scala/org/labrad/manager/Handlers.scala
+++ b/src/main/scala/org/labrad/manager/Handlers.scala
@@ -43,17 +43,8 @@ class ClientHandler(
 )
 extends SimpleChannelInboundHandler[Packet] with ClientActor with ManagerSupport with Logging {
 
-  // handle scala Future callbacks on netty threads
-  private var _executionContext: ExecutionContext = null
-
-  protected implicit def executionContext: ExecutionContext = {
-    require(_executionContext != null, "No ExecutionContext set!")
-    _executionContext
-  }
-
-  override def handlerAdded(ctx: ChannelHandlerContext): Unit = {
-    _executionContext = ExecutionContext.fromExecutorService(ctx.channel.eventLoop)
-  }
+  // Handle scala Future callbacks on the global execution context.
+  protected implicit def executionContext = ExecutionContext.global
 
   // handle incoming packets
   override def channelRead0(ctx: ChannelHandlerContext, packet: Packet): Unit = {

--- a/src/main/scala/org/labrad/manager/Manager.scala
+++ b/src/main/scala/org/labrad/manager/Manager.scala
@@ -59,11 +59,9 @@ class CentralNode(
   val workerGroup = Listener.newWorkerGroup()
   val loginGroup = Listener.newLoginGroup()
 
-  val nettyExecutionContext = ExecutionContext.fromExecutor(workerGroup)
-
   // start services
   val tracker = new StatsTrackerImpl
-  val hub: Hub = new HubImpl(tracker, () => messager)(nettyExecutionContext)
+  val hub: Hub = new HubImpl(tracker, () => messager)(ExecutionContext.global)
   val messager: Messager = new MessagerImpl(hub, tracker)
   val auth: AuthService = new AuthServiceImpl(password)
 
@@ -82,7 +80,7 @@ class CentralNode(
     val id = hub.allocateServerId(name)
     val registry = new Registry(id, name, regStore, externalConfig)(serversExecutionContext)
     hub.setServerInfo(ServerInfo(registry.id, registry.name, registry.doc, registry.settings))
-    hub.connectServer(id, name, new LocalServerActor(registry, hub, tracker)(nettyExecutionContext))
+    hub.connectServer(id, name, new LocalServerActor(registry, hub, tracker)(ExecutionContext.global))
   }
 
   for (authStore <- authStoreOpt) {
@@ -98,7 +96,7 @@ class CentralNode(
     }
     val auth = new AuthServer(id, name, hub, authStore, verifierOpt, regStore, externalConfig)(serversExecutionContext)
     hub.setServerInfo(ServerInfo(auth.id, auth.name, auth.doc, auth.settings))
-    hub.connectServer(id, name, new LocalServerActor(auth, hub, tracker)(nettyExecutionContext))
+    hub.connectServer(id, name, new LocalServerActor(auth, hub, tracker)(ExecutionContext.global))
   }
 
   // start listening for incoming network connections


### PR DESCRIPTION
When using a netty `EventLoopGroup` as a scala `ExecutionContext`, we observe the some `Future`s fail to be completed properly, leading to timeout errors when `Await`-ing those `Future`s.

In particular, when calling the `expireContext` setting on the manager, the `Hub` [returns](https://github.com/labrad/scalabrad/blob/u/maffoo/execution-contexts/src/main/scala/org/labrad/manager/Hub.scala#L222) a `Future` which the manager [awaits](https://github.com/labrad/scalabrad/blob/u/maffoo/execution-contexts/src/main/scala/org/labrad/manager/Handlers.scala#L407), and we see occasional timeouts. Looking at the stack traces in the manager, there does not appear to be a deadlock between threads, rather it seems that the Future callbacks are just not getting set up and run properly by the netty execution context.

To avoid this issue, we replace the netty-backed execution contexts by the standard global execution context, which is similarly meant for short callbacks that do not block. Blocking server work is still handled on execution contexts backed by cached thread pools, to avoid blocking the network or future callback threads.
