### PR TITLE
Move TestUtils functions into main classpath.

### DIFF
--- a/src/main/scala/org/labrad/util/Await.scala
+++ b/src/main/scala/org/labrad/util/Await.scala
@@ -5,6 +5,31 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 object Await {
+  /**
+   * Convenience method to await a Future with a default timeout, which
+   * can be overridden if desired
+   */
+  def apply[A](f: Future[A], timeout: Duration = 30.seconds): A = {
+    result(f, timeout)
+  }
+
+  /**
+   * Await the result of a Future, or raise a TimeoutException if the result
+   * does not arrive within the given timeout. This has the same interface as
+   * scala.concurrent.Await except that if the Future fails we throw a new
+   * exception created here. This ensures that the line where Await was called
+   * appears in the stack trace, as opposed to scala.concurrent.Await which
+   * just rethrows the original exception including its stack trace and so the
+   * exception which propagates does not include the stack up to the point
+   * where .result was called.
+   *
+   * Because we want to throw a new exception to get stack trace information,
+   * we have to wrap the thrown exception with our own exception, which means
+   * we lose the exception type. To deal with this, custom exception types can
+   * extend Rethrowable which provides machinery for creating a copy of the
+   * exception which will capture the local stack trace but refer back to the
+   * original exception as the underlying cause.
+   */
   def result[A](f: Future[A], timeout: Duration): A = {
     try {
       scala.concurrent.Await.result(f, timeout)
@@ -23,6 +48,11 @@ object Await {
   }
 }
 
+/**
+ * Superclass for exceptions that know how to copy themselves to be rethrown.
+ * This is used by Await to throw the same Exception type but a new local stack
+ * trace when dealing with failed Futures.
+ */
 trait Rethrowable extends Throwable {
   def rethrow(): Nothing = {
     val ex = copy()

--- a/src/main/scala/org/labrad/util/Files.scala
+++ b/src/main/scala/org/labrad/util/Files.scala
@@ -1,0 +1,42 @@
+package org.labrad.util
+
+import java.io.File
+
+object Files {
+
+  /**
+   * Call the given function with a newly-created temporary file, then delete
+   * the file after the function returns.
+   */
+  def withTempFile[T](body: File => T) = {
+    val f = File.createTempFile("sclabrad-tmp-", "")
+    try {
+      body(f)
+    } finally {
+      f.delete()
+    }
+  }
+
+  /**
+   * Call the given function with a newly-created temporary directory, then
+   * delete the directory and all its contents after the function returns.
+   */
+  def withTempDir[T](body: File => T) = {
+    val f = File.createTempFile("scalabrad-tmp-", "")
+    f.delete()
+    f.mkdir()
+    try {
+      body(f)
+    } finally {
+      def delete(f: File) {
+        if (f.isDirectory) {
+          for (child <- f.listFiles()) {
+            delete(child)
+          }
+        }
+        f.delete()
+      }
+      delete(f)
+    }
+  }
+}

--- a/src/main/scala/org/labrad/util/package.scala
+++ b/src/main/scala/org/labrad/util/package.scala
@@ -2,7 +2,6 @@ package org.labrad.util
 
 import java.io.{File, IOException}
 import java.net.{DatagramSocket, ServerSocket, URI}
-import java.nio.file.Files
 import java.util.regex.Pattern
 
 
@@ -169,7 +168,7 @@ object Util {
    */
   def copy(src: File, dst: File): Unit = {
     Util.ensureDir(dst.getParentFile)
-    Files.copy(src.toPath, dst.toPath)
+    java.nio.file.Files.copy(src.toPath, dst.toPath)
   }
 
   /**

--- a/src/test/scala/org/labrad/ClientTest.scala
+++ b/src/test/scala/org/labrad/ClientTest.scala
@@ -4,7 +4,7 @@ import java.io.File
 import java.nio.ByteOrder
 import java.util.{Date, Random}
 import org.labrad.data._
-import org.labrad.manager.CentralNode
+import org.labrad.manager.ManagerUtils
 import org.labrad.types._
 import org.labrad.util.{Logging, Util}
 import org.scalatest.FunSuite
@@ -14,8 +14,8 @@ import scala.concurrent.duration._
 class ClientTest extends FunSuite {
 
   def testWithClient(name: String)(func: Client => Unit) = test(name) {
-    TestUtils.withManager() { m =>
-      TestUtils.withClient(host = m.host, port = m.port, credential = m.credential) { c =>
+    ManagerUtils.withManager() { m =>
+      ManagerUtils.withClient(m) { c =>
         func(c)
       }
     }

--- a/src/test/scala/org/labrad/RegistryTest.scala
+++ b/src/test/scala/org/labrad/RegistryTest.scala
@@ -2,29 +2,30 @@ package org.labrad
 
 import org.labrad.annotations._
 import org.labrad.data._
+import org.labrad.manager.ManagerUtils
 import org.labrad.registry._
 import org.labrad.types._
+import org.labrad.util.{Await, Files}
 import org.scalatest.{FunSuite, Matchers, Tag}
 import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.time.SpanSugar._
 import scala.collection._
-import scala.concurrent.{Await, Future}
 
 class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 
-  import TestUtils._
+  import ManagerUtils._
 
   def testAllBackends(testName: String)(func: (RegistryStore, Boolean) => Unit): Unit = {
     test(s"BinaryFileStore: $testName") {
-      withTempDir { dir => func(new BinaryFileStore(dir), true) }
+      Files.withTempDir { dir => func(new BinaryFileStore(dir), true) }
     }
 
     test(s"DelphiFileStore: $testName", Tag("delphi")) {
-      withTempDir { dir => func(new DelphiFileStore(dir), false) }
+      Files.withTempDir { dir => func(new DelphiFileStore(dir), false) }
     }
 
     test(s"SQLiteStore: $testName") {
-      withTempFile { file => func(SQLiteStore(file), true) }
+      Files.withTempFile { file => func(SQLiteStore(file), true) }
     }
   }
 
@@ -89,19 +90,19 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("registry can store and retrieve arbitrary data") {
     withManager() { m =>
-      withClient(m.host, m.port, m.credential) { c =>
-        await(c.send("Registry", "mkdir" -> Str("test"), "cd" -> Str("test")))
+      withClient(m) { c =>
+        Await(c.send("Registry", "mkdir" -> Str("test"), "cd" -> Str("test")))
         try {
           for (i <- 0 until 1000) {
             val tpe = Hydrant.randomType
             val data = Hydrant.randomData(tpe)
-            await(c.send("Registry", "set" -> Cluster(Str("a"), data)))
-            val resp = await(c.send("Registry", "get" -> Str("a")))(0)
-            await(c.send("Registry", "del" -> Str("a")))
+            Await(c.send("Registry", "set" -> Cluster(Str("a"), data)))
+            val resp = Await(c.send("Registry", "get" -> Str("a")))(0)
+            Await(c.send("Registry", "del" -> Str("a")))
             assert(resp == data, s"${resp} (type=${resp.t}) is not equal to ${data} (type=${data.t})")
           }
         } finally {
-          await(c.send("Registry", "cd" -> Str(".."), "rmdir" -> Str("test")))
+          Await(c.send("Registry", "cd" -> Str(".."), "rmdir" -> Str("test")))
         }
       }
     }
@@ -109,25 +110,25 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("registry can deal with unicode and strange characters in directory names", Tag("chars")) {
     withManager() { m =>
-      withClient(m.host, m.port, m.credential) { c =>
+      withClient(m) { c =>
         val dir = "<\u03C0|\u03C1>??+*\\/:|"
-        await(c.send("Registry", "mkdir" -> Str(dir)))
-        val (dirs, _) = await(c.send("Registry", "dir" -> Data.NONE))(0).get[(Seq[String], Seq[String])]
+        Await(c.send("Registry", "mkdir" -> Str(dir)))
+        val (dirs, _) = Await(c.send("Registry", "dir" -> Data.NONE))(0).get[(Seq[String], Seq[String])]
         assert(dirs contains dir)
-        await(c.send("Registry", "cd" -> Str(dir)))
+        Await(c.send("Registry", "cd" -> Str(dir)))
       }
     }
   }
 
   test("registry can deal with unicode and strange characters in key names", Tag("chars")) {
     withManager() { m =>
-      withClient(m.host, m.port, m.credential) { c =>
+      withClient(m) { c =>
         val key = "<\u03C0|\u03C1>??+*\\/:|"
         val data = Str("Hello!")
-        await(c.send("Registry", "set" -> Cluster(Str(key), Str("Hello!"))))
-        val (_, keys) = await(c.send("Registry", "dir" -> Data.NONE))(0).get[(Seq[String], Seq[String])]
+        Await(c.send("Registry", "set" -> Cluster(Str(key), Str("Hello!"))))
+        val (_, keys) = Await(c.send("Registry", "dir" -> Data.NONE))(0).get[(Seq[String], Seq[String])]
         assert(keys contains key)
-        val result = await(c.send("Registry", "get" -> Str(key)))(0)
+        val result = Await(c.send("Registry", "get" -> Str(key)))(0)
         assert(result == data)
       }
     }
@@ -135,9 +136,9 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("registry cd with no arguments stays in same directory") {
     withManager() { m =>
-      withClient(m.host, m.port, m.credential) { c =>
-        await(c.send("Registry", "cd" -> Cluster(Arr(Str("test"), Str("a")), Bool(true))))
-        val result = await(c.send("Registry", "cd" -> Data.NONE))(0)
+      withClient(m) { c =>
+        Await(c.send("Registry", "cd" -> Cluster(Arr(Str("test"), Str("a")), Bool(true))))
+        val result = Await(c.send("Registry", "cd" -> Data.NONE))(0)
         assert(result.get[Seq[String]] == Seq("", "test", "a"))
       }
     }
@@ -145,7 +146,7 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("registry sends message when key is created") {
     withManager() { m =>
-      withClient(m.host, m.port, m.credential) { c =>
+      withClient(m) { c =>
 
         val w = new Waiter
 
@@ -157,9 +158,9 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
             w.dismiss
         }
 
-        await(c.send("Registry", "mkdir" -> Str("test"), "cd" -> Str("test")))
-        await(c.send("Registry", "Notify on Change" -> Cluster(UInt(msgId), Bool(true))))
-        await(c.send("Registry", "set" -> Cluster(Str("a"), Str("test"))))
+        Await(c.send("Registry", "mkdir" -> Str("test"), "cd" -> Str("test")))
+        Await(c.send("Registry", "Notify on Change" -> Cluster(UInt(msgId), Bool(true))))
+        Await(c.send("Registry", "set" -> Cluster(Str("a"), Str("test"))))
         w.await(timeout(10.seconds))
       }
     }
@@ -167,7 +168,7 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("registry sends message when key is changed") {
     withManager() { m =>
-      withClient(m.host, m.port, m.credential) { c =>
+      withClient(m) { c =>
 
         val w = new Waiter
 
@@ -179,10 +180,10 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
             w.dismiss
         }
 
-        await(c.send("Registry", "mkdir" -> Str("test"), "cd" -> Str("test")))
-        await(c.send("Registry", "set" -> Cluster(Str("a"), Str("first"))))
-        await(c.send("Registry", "Notify on Change" -> Cluster(UInt(msgId), Bool(true))))
-        await(c.send("Registry", "set" -> Cluster(Str("a"), Str("second"))))
+        Await(c.send("Registry", "mkdir" -> Str("test"), "cd" -> Str("test")))
+        Await(c.send("Registry", "set" -> Cluster(Str("a"), Str("first"))))
+        Await(c.send("Registry", "Notify on Change" -> Cluster(UInt(msgId), Bool(true))))
+        Await(c.send("Registry", "set" -> Cluster(Str("a"), Str("second"))))
         w.await
       }
     }
@@ -190,7 +191,7 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("registry sends message when key is deleted") {
     withManager() { m =>
-      withClient(m.host, m.port, m.credential) { c =>
+      withClient(m) { c =>
 
         val w = new Waiter
 
@@ -202,10 +203,10 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
             w.dismiss
         }
 
-        await(c.send("Registry", "mkdir" -> Str("test"), "cd" -> Str("test")))
-        await(c.send("Registry", "set" -> Cluster(Str("a"), Str("first"))))
-        await(c.send("Registry", "Notify on Change" -> Cluster(UInt(msgId), Bool(true))))
-        await(c.send("Registry", "del" -> Str("a")))
+        Await(c.send("Registry", "mkdir" -> Str("test"), "cd" -> Str("test")))
+        Await(c.send("Registry", "set" -> Cluster(Str("a"), Str("first"))))
+        Await(c.send("Registry", "Notify on Change" -> Cluster(UInt(msgId), Bool(true))))
+        Await(c.send("Registry", "del" -> Str("a")))
         w.await
       }
     }
@@ -226,24 +227,24 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("deleting a registry directory containing a dir should fail") {
     withManager() { m =>
-      withClient(m.host, m.port, m.credential) { c =>
+      withClient(m) { c =>
 
         val reg = new RegistryServerProxy(c)
-        await(reg.cd(Seq("a", "b"), true))
+        Await(reg.cd(Seq("a", "b"), true))
 
         def dirs(): Seq[String] = {
-          val (ds, ks) = await(reg.dir())
+          val (ds, ks) = Await(reg.dir())
           ds
         }
 
-        await(reg.cd(".."))
+        Await(reg.cd(".."))
         assert(dirs() contains "b")
 
-        await(reg.cd(".."))
+        Await(reg.cd(".."))
         assert(dirs() contains "a")
 
         intercept[Exception] {
-          await(reg.rmDir("a"))
+          Await(reg.rmDir("a"))
         }
       }
     }
@@ -251,19 +252,19 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("deleting a registry directory containing a key should fail") {
     withManager() { m =>
-      withClient(m.host, m.port, m.credential) { c =>
+      withClient(m) { c =>
 
         val reg = new RegistryServerProxy(c)
-        await(reg.cd(Seq("a"), true))
-        await(reg.set("blah", Str("test")))
+        Await(reg.cd(Seq("a"), true))
+        Await(reg.set("blah", Str("test")))
 
-        val (_, keys) = await(reg.dir())
+        val (_, keys) = Await(reg.dir())
         assert(keys contains "blah")
 
-        await(reg.cd(".."))
+        Await(reg.cd(".."))
 
         intercept[Exception] {
-          await(reg.rmDir("a"))
+          Await(reg.rmDir("a"))
         }
       }
     }
@@ -271,13 +272,13 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("creating a registry directory with empty name should fail", Tag("empties")) {
     withManager() { m =>
-      withClient(m.host, m.port, m.credential) { c =>
+      withClient(m) { c =>
 
         val reg = new RegistryServerProxy(c)
-        await(reg.cd(Seq("test"), true))
+        Await(reg.cd(Seq("test"), true))
 
         intercept[Exception] {
-          await(reg.mkDir(""))
+          Await(reg.mkDir(""))
         }
       }
     }
@@ -285,63 +286,15 @@ class RegistryTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("creating a registry key with empty name should fail", Tag("empties")) {
     withManager() { m =>
-      withClient(m.host, m.port, m.credential) { c =>
+      withClient(m) { c =>
 
         val reg = new RegistryServerProxy(c)
-        await(reg.cd(Seq("test"), true))
+        Await(reg.cd(Seq("test"), true))
 
         intercept[Exception] {
-          await(reg.set("", Str("not allowed")))
+          Await(reg.set("", Str("not allowed")))
         }
       }
-    }
-  }
-}
-
-object RegistryTest {
-
-  import TestUtils._
-
-  def main(args: Array[String]): Unit = {
-    val (host, port) = args match {
-      case Array(host) =>
-        host.split(":") match {
-          case Array(host, port) => host -> port.toInt
-          case Array(host) => host -> 7682
-        }
-
-      case Array() =>
-        "localhost" -> 7682
-    }
-
-    withClient(host, port, credential = Password("", Array())) { c =>
-      val reg = new RegistryServerProxy(c)
-      val (dirs, keys) = await(reg.dir())
-      if (!dirs.contains("test")) {
-        await(reg.mkDir("test"))
-      }
-      await(reg.cd("test"))
-
-      def mkdir(level: Int = 0): Unit = {
-        if (level < 3) {
-          for (i <- 0 until 3) {
-            val dir = s"dir$i"
-            await(reg.mkDir(dir))
-            await(reg.cd(dir))
-            mkdir(level + 1)
-            await(reg.cd(".."))
-          }
-        }
-        for (i <- 0 until 10) {
-          val key = f"key$i%03d"
-          val tpe = Hydrant.randomType
-          val data = Hydrant.randomData(tpe)
-          await(reg.set(key, data))
-          val resp = await(reg.get(key))
-          assert(resp ~== data, s"${resp} (type=${resp.t}) is not equal to ${data} (type=${data.t})")
-        }
-      }
-      mkdir()
     }
   }
 }

--- a/src/test/scala/org/labrad/TlsTest.scala
+++ b/src/test/scala/org/labrad/TlsTest.scala
@@ -2,7 +2,7 @@ package org.labrad
 
 import java.io.File
 import org.labrad.data._
-import org.labrad.manager.TlsPolicy
+import org.labrad.manager.{ManagerUtils, TlsPolicy}
 import org.labrad.types._
 import org.scalatest.FunSuite
 import scala.concurrent.Await
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 
 class TlsTest extends FunSuite {
 
-  import TestUtils._
+  import ManagerUtils._
 
   def connectWithMode(tls: TlsMode, includeCerts: Boolean = true)(implicit m: ManagerInfo): Unit = {
     val certs = if (includeCerts) {
@@ -18,7 +18,7 @@ class TlsTest extends FunSuite {
     } else {
       Map.empty[String, File]
     }
-    withClient(m.host, m.port, m.credential, tls = tls, tlsCerts = certs) { c =>
+    withClient(m, tls = tls, tlsCerts = certs) { c =>
       val mgr = new ManagerServerProxy(c)
       Await.result(mgr.servers(), 1.second)
     }

--- a/src/test/scala/org/labrad/manager/auth/AuthStoreTest.scala
+++ b/src/test/scala/org/labrad/manager/auth/AuthStoreTest.scala
@@ -1,15 +1,8 @@
 package org.labrad.manager.auth
 
-import org.labrad.TestUtils
-import org.labrad.annotations._
-import org.labrad.data._
 import org.labrad.registry._
-import org.labrad.types._
+import org.labrad.util.Files
 import org.scalatest.fixture.FunSuite
-import org.scalatest.concurrent.AsyncAssertions
-import org.scalatest.time.SpanSugar._
-import scala.collection._
-import scala.concurrent.{Await, Future}
 
 class AuthStoreTest extends FunSuite {
 
@@ -17,7 +10,7 @@ class AuthStoreTest extends FunSuite {
   type FixtureParam = Fixture
 
   def withFixture(test: OneArgTest) = {
-    TestUtils.withTempFile { file =>
+    Files.withTempFile { file =>
       val authStore = AuthStore(file)
       withFixture(test.toNoArgTest(Fixture(authStore)))
     }

--- a/src/test/scala/org/labrad/registry/RemoteStoreTest.scala
+++ b/src/test/scala/org/labrad/registry/RemoteStoreTest.scala
@@ -1,19 +1,20 @@
 package org.labrad.registry
 
-import org.labrad.{ManagerInfo, RegistryServerProxy, TlsMode}
+import org.labrad.{RegistryServerProxy, TlsMode}
 import org.labrad.annotations._
 import org.labrad.data._
+import org.labrad.manager.ManagerUtils
 import org.labrad.registry._
 import org.labrad.types._
+import org.labrad.util.Await
 import org.scalatest.{FunSuite, Matchers, Tag}
 import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.time.SpanSugar._
 import scala.collection._
-import scala.concurrent.{Await, Future}
 
 class RemoteStoreTest extends FunSuite with Matchers with AsyncAssertions {
 
-  import org.labrad.TestUtils._
+  import ManagerUtils._
 
   def withManagers()(func: (ManagerInfo, ManagerInfo, ManagerInfo) => Unit): Unit = {
     withManager() { root =>
@@ -28,8 +29,8 @@ class RemoteStoreTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("remote registry gets message when key is created") {
     withManagers() { (root, leaf1, leaf2) =>
-      withClient(leaf1.host, leaf1.port, leaf1.credential) { c1 =>
-        withClient(leaf2.host, leaf2.port, leaf2.credential) { c2 =>
+      withClient(leaf1) { c1 =>
+        withClient(leaf2) { c2 =>
 
           val r1 = new RegistryServerProxy(c1)
           val r2 = new RegistryServerProxy(c2)
@@ -44,13 +45,13 @@ class RemoteStoreTest extends FunSuite with Matchers with AsyncAssertions {
               w.dismiss
           }
 
-          await(r1.mkDir("test"))
-          await(r1.cd("test"))
+          Await(r1.mkDir("test"))
+          Await(r1.cd("test"))
 
-          await(r2.notifyOnChange(msgId, true))
-          await(r2.cd("test"))
+          Await(r2.notifyOnChange(msgId, true))
+          Await(r2.cd("test"))
 
-          await(r1.set("a", Str("test")))
+          Await(r1.set("a", Str("test")))
           w.await(timeout(10.seconds))
         }
       }
@@ -59,8 +60,8 @@ class RemoteStoreTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("remote registry gets message when key is changed") {
     withManagers() { (root, leaf1, leaf2) =>
-      withClient(leaf1.host, leaf1.port, leaf1.credential) { c1 =>
-        withClient(leaf2.host, leaf2.port, leaf2.credential) { c2 =>
+      withClient(leaf1) { c1 =>
+        withClient(leaf2) { c2 =>
 
           val r1 = new RegistryServerProxy(c1)
           val r2 = new RegistryServerProxy(c2)
@@ -75,14 +76,14 @@ class RemoteStoreTest extends FunSuite with Matchers with AsyncAssertions {
               w.dismiss
           }
 
-          await(r1.mkDir("test"))
-          await(r1.cd("test"))
-          await(r1.set("a", Str("first")))
+          Await(r1.mkDir("test"))
+          Await(r1.cd("test"))
+          Await(r1.set("a", Str("first")))
 
-          await(r2.notifyOnChange(msgId, true))
-          await(r2.cd("test"))
+          Await(r2.notifyOnChange(msgId, true))
+          Await(r2.cd("test"))
 
-          await(r1.set("a", Str("second")))
+          Await(r1.set("a", Str("second")))
           w.await(timeout(10.seconds))
         }
       }
@@ -91,8 +92,8 @@ class RemoteStoreTest extends FunSuite with Matchers with AsyncAssertions {
 
   test("remote registry gets message when key is deleted") {
     withManagers() { (root, leaf1, leaf2) =>
-      withClient(leaf1.host, leaf1.port, leaf1.credential) { c1 =>
-        withClient(leaf2.host, leaf2.port, leaf2.credential) { c2 =>
+      withClient(leaf1) { c1 =>
+        withClient(leaf2) { c2 =>
 
           val r1 = new RegistryServerProxy(c1)
           val r2 = new RegistryServerProxy(c2)
@@ -107,14 +108,14 @@ class RemoteStoreTest extends FunSuite with Matchers with AsyncAssertions {
               w.dismiss
           }
 
-          await(r1.mkDir("test"))
-          await(r1.cd("test"))
-          await(r1.set("a", Str("first")))
+          Await(r1.mkDir("test"))
+          Await(r1.cd("test"))
+          Await(r1.set("a", Str("first")))
 
-          await(r2.notifyOnChange(msgId, true))
-          await(r2.cd("test"))
+          Await(r2.notifyOnChange(msgId, true))
+          Await(r2.cd("test"))
 
-          await(r1.del("a"))
+          Await(r1.del("a"))
           w.await(timeout(10.seconds))
         }
       }


### PR DESCRIPTION
This will allow these utilities to be used by other downstream projects, without needing to publish any additional jars. We split the various functions up by their purpose (dealing with temp files, dealing with Futures in a blocking manner, and running temporary managers and clients).
