### PR TITLE
Allow composing command line options from multiple traits.

### DIFF
--- a/core/src/main/scala/org/labrad/Server.scala
+++ b/core/src/main/scala/org/labrad/Server.scala
@@ -10,6 +10,7 @@ import org.labrad.concurrent.ExecutionContexts
 import org.labrad.data._
 import org.labrad.errors.LabradException
 import org.labrad.util.{AsyncSemaphore, Logging, Util}
+import org.labrad.util.cli.Command
 import scala.collection.mutable
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
@@ -261,14 +262,14 @@ object Server {
    * Includes basic parsing of command line options.
    */
   def run(s: IServer, args: Array[String]): Unit = {
-    val config = ServerConfig.fromCommandLine(args) match {
-      case Success(config) => config
-
-      case Failure(e: ArgotUsageException) =>
+    val config = try {
+      ServerConfig.fromCommandLine(args)
+    } catch {
+      case e: ArgotUsageException =>
         println(e.message)
         return
 
-      case Failure(e: Throwable) =>
+      case e: Throwable =>
         println(s"unexpected error: $e")
         return
     }
@@ -360,25 +361,10 @@ object ServerConfig {
   }
 
   /**
-   * Create ServerConfig from command line and map of environment variables.
-   *
-   * @param args command line parameters
-   * @param env map of environment variables, which defaults to the actual
-   *        environment variables in scala.sys.env
-   * @return a Try containing a ServerArgs instance (on success) or a Failure
-   *         in the case something went wrong. The Failure will contain an
-   *         ArgotUsageException if the command line parsing failed or the
-   *         -h or --help options were supplied.
+   * Command line options for creating ServerConfig.
    */
-  def fromCommandLine(
-    args: Array[String],
-    env: Map[String, String] = scala.sys.env
-  ): Try[ServerConfig] = {
-    val parser = new ArgotParser("labrad-server",
-      preUsage = Some("Run a labrad server."),
-      sortUsage = false
-    )
-    val nameOpt = parser.option[String](
+  trait Options { _: Command =>
+    val name = parser.option[String](
       names = List("name"),
       valueName = "string",
       description = "The name to use for this server when connecting to the " +
@@ -386,21 +372,21 @@ object ServerConfig {
         "This is generally not needed, but can be useful in testing if you " +
         "want to run several copies of a given server without name conflicts."
     )
-    val hostOpt = parser.option[String](
+    val host = parser.option[String](
       names = List("host"),
       valueName = "string",
       description = "The hostname where the labrad manager is running. " +
         "If not provided, fallback to the value given in the LABRADHOST " +
         "environment variable, with default value 'localhost'."
     )
-    val portOpt = parser.option[Int](
+    val port = parser.option[Int](
       names = List("port"),
       valueName = "int",
       description = "Port on which to connect to the labrad manager. " +
         "If not provided, fallback to the value given in the LABRADPORT " +
         "environment variable, with default value 7682."
     )
-    val tlsOpt = parser.option[String](
+    val tls = parser.option[String](
       names = List("tls"),
       valueName = "string",
       description = "The TLS mode to use for secure connections to the " +
@@ -415,42 +401,71 @@ object ServerConfig {
         "localhost. Finally, 'off' will disable TLS entirely; this is " +
         "recommended only for use with legacy managers."
     )
-    val tlsPortOpt = parser.option[Int](
+    val tlsPort = parser.option[Int](
       names = List("tls-port"),
       valueName = "int",
       description = "Port on which to connect to the labrad manager with " +
         "TLS. If not provided, fallback to the value given in the " +
         "LABRAD_TLS_PORT environment variable, with default value 7643."
     )
-    val usernameOpt = parser.option[String](
+    val username = parser.option[String](
       names = List("username"),
       valueName = "string",
       description = "Username to use to authenticate to the manager. " +
         "If not provided, fallback to the value given in the LABRADUSER " +
         "environment variable, with default value '' (global user)."
     )
-    val passwordOpt = parser.option[String](
+    val password = parser.option[String](
       names = List("password"),
       valueName = "string",
       description = "Password to use to authenticate to the manager. " +
         "If not provided, fallback to the value given in the LABRADPASSWORD " +
         "environment variable, with default value '' (empty password)."
     )
-    val help = parser.flag[Boolean](List("h", "help"),
-      "Print usage information and exit")
+  }
 
-    Try {
-      parser.parse(args)
-      if (help.value.getOrElse(false)) parser.usage()
+  /**
+   * Create ServerConfig from command line and map of environment variables.
+   *
+   * @param args command line parameters
+   * @param env map of environment variables, which defaults to the actual
+   *        environment variables in scala.sys.env
+   * @return a ServerConfig instance if the args were parsed successfully.
+   * @raises ArgotUsageException if the command line parsing failed or the
+   *         -h or --help options were supplied.
+   */
+  def fromCommandLine(
+    args: Array[String],
+    env: Map[String, String] = scala.sys.env
+  ): ServerConfig = {
+    val options = (new Command("labrad-server") with Options).parse(args)
+    fromOptions(options, env)
+  }
 
-      val host = hostOpt.value.orElse(env.get("LABRADHOST")).getOrElse("localhost")
-      val port = portOpt.value.orElse(env.get("LABRADPORT").map(_.toInt)).getOrElse(7682)
-      val tls = tlsOpt.value.orElse(env.get("LABRAD_TLS")).map(TlsMode.fromString).getOrElse(ServerConfig.Defaults.tls)
-      val tlsPort = tlsPortOpt.value.orElse(env.get("LABRAD_TLS_PORT").map(_.toInt)).getOrElse(ServerConfig.Defaults.tlsPort)
-      val username = usernameOpt.value.orElse(env.get("LABRADUSER")).getOrElse("")
-      val password = passwordOpt.value.orElse(env.get("LABRADPASSWORD")).getOrElse("").toCharArray
-
-      ServerConfig(host, port, Password(username, password), nameOpt.value, tls, tlsPort)
-    }
+  /**
+   * Create ServerConfig from Options instance and map of environment variables.
+   *
+   * @param args command line parameters
+   * @param env map of environment variables, which defaults to the actual
+   *        environment variables in scala.sys.env
+   * @return a ServerConfig instance if the args were parsed successfully.
+   * @raises ArgotUsageException if the command line parsing failed or the
+   *         -h or --help options were supplied.
+   */
+  def fromOptions(
+    options: Options,
+    env: Map[String, String] = scala.sys.env
+  ): ServerConfig = {
+    ServerConfig(
+      host = options.host.value.orElse(env.get("LABRADHOST")).getOrElse("localhost"),
+      port = options.port.value.orElse(env.get("LABRADPORT").map(_.toInt)).getOrElse(7682),
+      credential = Password(
+        username = options.username.value.orElse(env.get("LABRADUSER")).getOrElse(""),
+        password = options.password.value.orElse(env.get("LABRADPASSWORD")).getOrElse("").toCharArray
+      ),
+      nameOpt = options.name.value,
+      tls = options.tls.value.orElse(env.get("LABRAD_TLS")).map(TlsMode.fromString).getOrElse(Defaults.tls),
+      tlsPort = options.tlsPort.value.orElse(env.get("LABRAD_TLS_PORT").map(_.toInt)).getOrElse(Defaults.tlsPort)
+    )
   }
 }

--- a/core/src/main/scala/org/labrad/util/cli/Command.scala
+++ b/core/src/main/scala/org/labrad/util/cli/Command.scala
@@ -6,23 +6,20 @@ import org.clapper.argot.ArgotConverters._
 /**
  * Base class for command line options.
  *
- * To add options for a command, create traits that can be mixed in to Command
- * and use the parser member to define additional command line options.
+ * To add options for a command, create traits that can be mixed in to Command and use the parser
+ * member to define additional command line options.
  */
 class Command(name: String, doc: String = null) { self =>
 
-  protected val parser: ArgotParser =
-      new ArgotParser(name, preUsage = Option(doc))
+  protected val parser: ArgotParser = new ArgotParser(name, preUsage = Option(doc))
 
-  private val help = parser.flag[Boolean](List("h", "help"),
-      "Print usage information and exit")
+  private val help = parser.flag[Boolean](List("h", "help"), "Print usage information and exit")
 
   private var parsed = false
 
   /**
-   * Parse command line arguments. Returns self if parse was successful.
-   * Raises ArgotUsageException if the command line parsing failed or the
-   * -h or --help options were supplied.
+   * Parse command line arguments. Returns self if parse was successful. Throws ArgotUsageException
+   * if the command line parsing failed or the -h or --help options were supplied.
    */
   def parse(args: Array[String]): self.type = synchronized {
     require(!parsed, "already parsed command line")
@@ -31,4 +28,32 @@ class Command(name: String, doc: String = null) { self =>
     if (help.value.getOrElse(false)) parser.usage()
     self
   }
+}
+
+/**
+ * Holder for a map of environment variables.
+ *
+ * We use this instead of a plain Map[String, String] when passing the environment as an implicit
+ * variable since Map is a rather common type. This class itself implements Map[String, String], by
+ * forwarding calls to the underlying map instance.
+ */
+case class Environment(map: Map[String, String]) extends Map[String, String] {
+  override def empty: Environment = Environment(Map.empty[String, String])
+  def get(key: String): Option[String] = map.get(key)
+  def iterator: Iterator[(String, String)] = map.iterator
+  def + [B >: String](kv: (String, B)): Map[String, B] = map + kv
+  def - (key: String): Environment = Environment(map - key)
+}
+
+object Environment {
+
+  /**
+   * Convenience constructor to build an environment from a sequence of key-value tuples.
+   */
+  def apply(kvs: (String, String)*): Environment = new Environment(Map(kvs: _*))
+
+  /**
+   * Wrapper for the standard environment variables from scala.sys
+   */
+  lazy val sys = Environment(scala.sys.env)
 }

--- a/core/src/main/scala/org/labrad/util/cli/Command.scala
+++ b/core/src/main/scala/org/labrad/util/cli/Command.scala
@@ -1,0 +1,34 @@
+package org.labrad.util.cli
+
+import org.clapper.argot._
+import org.clapper.argot.ArgotConverters._
+
+/**
+ * Base class for command line options.
+ *
+ * To add options for a command, create traits that can be mixed in to Command
+ * and use the parser member to define additional command line options.
+ */
+class Command(name: String, doc: String = null) { self =>
+
+  protected val parser: ArgotParser =
+      new ArgotParser(name, preUsage = Option(doc))
+
+  private val help = parser.flag[Boolean](List("h", "help"),
+      "Print usage information and exit")
+
+  private var parsed = false
+
+  /**
+   * Parse command line arguments. Returns self if parse was successful.
+   * Raises ArgotUsageException if the command line parsing failed or the
+   * -h or --help options were supplied.
+   */
+  def parse(args: Array[String]): self.type = synchronized {
+    require(!parsed, "already parsed command line")
+    parsed = true
+    parser.parse(args)
+    if (help.value.getOrElse(false)) parser.usage()
+    self
+  }
+}

--- a/core/src/test/scala/org/labrad/ServerConfigTest.scala
+++ b/core/src/test/scala/org/labrad/ServerConfigTest.scala
@@ -1,19 +1,22 @@
 package org.labrad
 
 import java.net.URI
+import org.labrad.util.cli.Environment
 import org.scalatest.FunSuite
 import scala.util.{Failure, Success}
 
 class ServerConfigTest extends FunSuite {
+
+  // If not otherwise specified, use empty environment for these tests.
+  implicit val defaultEnv = Environment()
 
   test("default manager config works with empty command line and env") {
     ServerConfig.fromCommandLine(Array())
   }
 
   test("host can be set from environment variable") {
-    val config = ServerConfig.fromCommandLine(
-      Array(),
-      env = Map("LABRADHOST" -> "foo.com"))
+    val env = Environment("LABRADHOST" -> "foo.com")
+    val config = ServerConfig.fromCommandLine(Array())(env)
     assert(config.host == "foo.com")
   }
 
@@ -26,14 +29,14 @@ class ServerConfigTest extends FunSuite {
   }
 
   test("host command line arg overrides environment variable") {
-    val config = ServerConfig.fromCommandLine(
-      Array("--host=foo.com"),
-      env = Map("LABRADHOST" -> "bar.com"))
+    val env = Environment("LABRADHOST" -> "bar.com")
+    val config = ServerConfig.fromCommandLine(Array("--host=foo.com"))(env)
     assert(config.host == "foo.com")
   }
 
   test("port can be set from environment variable") {
-    val config = ServerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "7777"))
+    val env = Environment("LABRADPORT" -> "7777")
+    val config = ServerConfig.fromCommandLine(Array())(env)
     assert(config.port == 7777)
   }
 
@@ -46,15 +49,15 @@ class ServerConfigTest extends FunSuite {
   }
 
   test("port command line arg overrides environment variable") {
-    val config = ServerConfig.fromCommandLine(
-      Array("--port=1234"),
-      env = Map("LABRADPORT" -> "2345"))
+    val env = Environment("LABRADPORT" -> "2345")
+    val config = ServerConfig.fromCommandLine(Array("--port=1234"))(env)
     assert(config.port == 1234)
   }
 
   test("port env var must be an integer") {
+    val env = Environment("LABRADPORT" -> "foo")
     intercept[Exception] {
-      ServerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "foo"))
+      ServerConfig.fromCommandLine(Array())(env)
     }
   }
 
@@ -66,9 +69,8 @@ class ServerConfigTest extends FunSuite {
 
 
   test("username can be set from environment variable") {
-    val config = ServerConfig.fromCommandLine(
-      Array(),
-      env = Map("LABRADUSER" -> "foo"))
+    val env = Environment("LABRADUSER" -> "foo")
+    val config = ServerConfig.fromCommandLine(Array())(env)
     val Password(username, _) = config.credential
     assert(username == "foo")
   }
@@ -84,9 +86,8 @@ class ServerConfigTest extends FunSuite {
   }
 
   test("username command line arg overrides environment variable") {
-    val config = ServerConfig.fromCommandLine(
-      Array("--username=foo"),
-      env = Map("LABRADUSER" -> "bar"))
+    val env = Environment("LABRADUSER" -> "bar")
+    val config = ServerConfig.fromCommandLine(Array("--username=foo"))(env)
     val Password(username, _) = config.credential
     assert(username == "foo")
   }
@@ -98,9 +99,8 @@ class ServerConfigTest extends FunSuite {
   }
 
   test("password can be set from environment variable") {
-    val config = ServerConfig.fromCommandLine(
-      Array(),
-      env = Map("LABRADPASSWORD" -> "foo"))
+    val env = Environment("LABRADPASSWORD" -> "foo")
+    val config = ServerConfig.fromCommandLine(Array())(env)
     checkPassword(config, "foo")
   }
 
@@ -113,9 +113,8 @@ class ServerConfigTest extends FunSuite {
   }
 
   test("password command line arg overrides environment variable") {
-    val config = ServerConfig.fromCommandLine(
-      Array("--password=foo"),
-      env = Map("LABRADPASSWORD" -> "bar"))
+    val env = Environment("LABRADPASSWORD" -> "bar")
+    val config = ServerConfig.fromCommandLine(Array("--password=foo"))(env)
     checkPassword(config, "foo")
   }
 
@@ -135,7 +134,8 @@ class ServerConfigTest extends FunSuite {
 
 
   test("tls-port can be set from environment variable") {
-    val config = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "7777"))
+    val env = Environment("LABRAD_TLS_PORT" -> "7777")
+    val config = ServerConfig.fromCommandLine(Array())(env)
     assert(config.tlsPort == 7777)
   }
 
@@ -148,15 +148,15 @@ class ServerConfigTest extends FunSuite {
   }
 
   test("tls-port command line arg overrides environment variable") {
-    val config = ServerConfig.fromCommandLine(
-      Array("--tls-port=1234"),
-      env = Map("LABRAD_TLS_PORT" -> "2345"))
+    val env = Environment("LABRAD_TLS_PORT" -> "2345")
+    val config = ServerConfig.fromCommandLine(Array("--tls-port=1234"))(env)
     assert(config.tlsPort == 1234)
   }
 
   test("tls-port env var must be an integer") {
+    val env = Environment("LABRAD_TLS_PORT" -> "foo")
     intercept[Exception] {
-      ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "foo"))
+      ServerConfig.fromCommandLine(Array())(env)
     }
   }
 
@@ -168,7 +168,8 @@ class ServerConfigTest extends FunSuite {
 
 
   test("tls mode can be set from environment variable") {
-    val config = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS" -> "on"))
+    val env = Environment("LABRAD_TLS" -> "on")
+    val config = ServerConfig.fromCommandLine(Array())(env)
     assert(config.tls == TlsMode.ON)
   }
 
@@ -181,15 +182,15 @@ class ServerConfigTest extends FunSuite {
   }
 
   test("tls mode command line arg overrides environment variable") {
-    val config = ServerConfig.fromCommandLine(
-      Array("--tls=off"),
-      env = Map("LABRAD_TLS" -> "on"))
+    val env = Environment("LABRAD_TLS" -> "on")
+    val config = ServerConfig.fromCommandLine(Array("--tls=off"))(env)
     assert(config.tls == TlsMode.OFF)
   }
 
   test("tls mode env var must be a valid option") {
+    val env = Environment("LABRAD_TLS" -> "foo")
     intercept[Exception] {
-      ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS" -> "foo"))
+      ServerConfig.fromCommandLine(Array())(env)
     }
   }
 

--- a/core/src/test/scala/org/labrad/ServerConfigTest.scala
+++ b/core/src/test/scala/org/labrad/ServerConfigTest.scala
@@ -7,65 +7,66 @@ import scala.util.{Failure, Success}
 class ServerConfigTest extends FunSuite {
 
   test("default manager config works with empty command line and env") {
-    val tryConfig = ServerConfig.fromCommandLine(Array())
-    assert(tryConfig.isInstanceOf[Success[_]])
+    ServerConfig.fromCommandLine(Array())
   }
 
   test("host can be set from environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(
+    val config = ServerConfig.fromCommandLine(
       Array(),
       env = Map("LABRADHOST" -> "foo.com"))
     assert(config.host == "foo.com")
   }
 
   test("host can be set from command line") {
-    val Success(config1) = ServerConfig.fromCommandLine(Array("--host", "foo.com"))
+    val config1 = ServerConfig.fromCommandLine(Array("--host", "foo.com"))
     assert(config1.host == "foo.com")
 
-    val Success(config2) = ServerConfig.fromCommandLine(Array("--host=foo.com"))
+    val config2 = ServerConfig.fromCommandLine(Array("--host=foo.com"))
     assert(config2.host == "foo.com")
   }
 
   test("host command line arg overrides environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(
+    val config = ServerConfig.fromCommandLine(
       Array("--host=foo.com"),
       env = Map("LABRADHOST" -> "bar.com"))
     assert(config.host == "foo.com")
   }
 
   test("port can be set from environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "7777"))
+    val config = ServerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "7777"))
     assert(config.port == 7777)
   }
 
   test("port can be set from command line") {
-    val Success(config1) = ServerConfig.fromCommandLine(Array("--port", "7777"))
+    val config1 = ServerConfig.fromCommandLine(Array("--port", "7777"))
     assert(config1.port == 7777)
 
-    val Success(config2) = ServerConfig.fromCommandLine(Array("--port=7878"))
+    val config2 = ServerConfig.fromCommandLine(Array("--port=7878"))
     assert(config2.port == 7878)
   }
 
   test("port command line arg overrides environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(
+    val config = ServerConfig.fromCommandLine(
       Array("--port=1234"),
       env = Map("LABRADPORT" -> "2345"))
     assert(config.port == 1234)
   }
 
   test("port env var must be an integer") {
-    val tryConfig = ServerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ServerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "foo"))
+    }
   }
 
   test("port command line must be an integer") {
-    val tryConfig = ServerConfig.fromCommandLine(Array("--port=foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ServerConfig.fromCommandLine(Array("--port=foo"))
+    }
   }
 
 
   test("username can be set from environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(
+    val config = ServerConfig.fromCommandLine(
       Array(),
       env = Map("LABRADUSER" -> "foo"))
     val Password(username, _) = config.credential
@@ -73,17 +74,17 @@ class ServerConfigTest extends FunSuite {
   }
 
   test("username can be set from command line") {
-    val Success(config1) = ServerConfig.fromCommandLine(Array("--username", "foo"))
+    val config1 = ServerConfig.fromCommandLine(Array("--username", "foo"))
     val Password(username1, _) = config1.credential
     assert(username1 == "foo")
 
-    val Success(config2) = ServerConfig.fromCommandLine(Array("--username=foo"))
+    val config2 = ServerConfig.fromCommandLine(Array("--username=foo"))
     val Password(username2, _) = config2.credential
     assert(username2 == "foo")
   }
 
   test("username command line arg overrides environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(
+    val config = ServerConfig.fromCommandLine(
       Array("--username=foo"),
       env = Map("LABRADUSER" -> "bar"))
     val Password(username, _) = config.credential
@@ -97,22 +98,22 @@ class ServerConfigTest extends FunSuite {
   }
 
   test("password can be set from environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(
+    val config = ServerConfig.fromCommandLine(
       Array(),
       env = Map("LABRADPASSWORD" -> "foo"))
     checkPassword(config, "foo")
   }
 
   test("password can be set from command line") {
-    val Success(config1) = ServerConfig.fromCommandLine(Array("--password", "foo"))
+    val config1 = ServerConfig.fromCommandLine(Array("--password", "foo"))
     checkPassword(config1, "foo")
 
-    val Success(config2) = ServerConfig.fromCommandLine(Array("--password=foo"))
+    val config2 = ServerConfig.fromCommandLine(Array("--password=foo"))
     checkPassword(config2, "foo")
   }
 
   test("password command line arg overrides environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(
+    val config = ServerConfig.fromCommandLine(
       Array("--password=foo"),
       env = Map("LABRADPASSWORD" -> "bar"))
     checkPassword(config, "foo")
@@ -120,77 +121,81 @@ class ServerConfigTest extends FunSuite {
 
 
   test("server name can be set from command line") {
-    val Success(config1) = ServerConfig.fromCommandLine(Array("--name", "foo-server"))
+    val config1 = ServerConfig.fromCommandLine(Array("--name", "foo-server"))
     assert(config1.nameOpt == Some("foo-server"))
 
-    val Success(config2) = ServerConfig.fromCommandLine(Array("--name=foo-server"))
+    val config2 = ServerConfig.fromCommandLine(Array("--name=foo-server"))
     assert(config2.nameOpt == Some("foo-server"))
   }
 
   test("server name defaults to None") {
-    val Success(config) = ServerConfig.fromCommandLine(Array())
+    val config = ServerConfig.fromCommandLine(Array())
     assert(config.nameOpt == None)
   }
 
 
   test("tls-port can be set from environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "7777"))
+    val config = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "7777"))
     assert(config.tlsPort == 7777)
   }
 
   test("tls-port can be set from command line") {
-    val Success(config1) = ServerConfig.fromCommandLine(Array("--tls-port", "7777"))
+    val config1 = ServerConfig.fromCommandLine(Array("--tls-port", "7777"))
     assert(config1.tlsPort == 7777)
 
-    val Success(config2) = ServerConfig.fromCommandLine(Array("--tls-port=7878"))
+    val config2 = ServerConfig.fromCommandLine(Array("--tls-port=7878"))
     assert(config2.tlsPort == 7878)
   }
 
   test("tls-port command line arg overrides environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(
+    val config = ServerConfig.fromCommandLine(
       Array("--tls-port=1234"),
       env = Map("LABRAD_TLS_PORT" -> "2345"))
     assert(config.tlsPort == 1234)
   }
 
   test("tls-port env var must be an integer") {
-    val tryConfig = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "foo"))
+    }
   }
 
   test("tls-port command line must be an integer") {
-    val tryConfig = ServerConfig.fromCommandLine(Array("--tls-port=foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ServerConfig.fromCommandLine(Array("--tls-port=foo"))
+    }
   }
 
 
   test("tls mode can be set from environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS" -> "on"))
+    val config = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS" -> "on"))
     assert(config.tls == TlsMode.ON)
   }
 
   test("tls mode can be set from command line") {
-    val Success(config1) = ServerConfig.fromCommandLine(Array("--tls", "on"))
+    val config1 = ServerConfig.fromCommandLine(Array("--tls", "on"))
     assert(config1.tls == TlsMode.ON)
 
-    val Success(config2) = ServerConfig.fromCommandLine(Array("--tls=on"))
+    val config2 = ServerConfig.fromCommandLine(Array("--tls=on"))
     assert(config2.tls == TlsMode.ON)
   }
 
   test("tls mode command line arg overrides environment variable") {
-    val Success(config) = ServerConfig.fromCommandLine(
+    val config = ServerConfig.fromCommandLine(
       Array("--tls=off"),
       env = Map("LABRAD_TLS" -> "on"))
     assert(config.tls == TlsMode.OFF)
   }
 
   test("tls mode env var must be a valid option") {
-    val tryConfig = ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS" -> "foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ServerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS" -> "foo"))
+    }
   }
 
   test("tls mode command line must be a valid option") {
-    val tryConfig = ServerConfig.fromCommandLine(Array("--tls=foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ServerConfig.fromCommandLine(Array("--tls=foo"))
+    }
   }
 }

--- a/manager/src/main/scala/org/labrad/manager/Manager.scala
+++ b/manager/src/main/scala/org/labrad/manager/Manager.scala
@@ -21,7 +21,7 @@ import org.labrad.manager.auth._
 import org.labrad.registry._
 import org.labrad.util._
 import org.labrad.util.Paths._
-import org.labrad.util.cli.Command
+import org.labrad.util.cli.{Command, Environment}
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Await}
 import scala.concurrent.duration._
@@ -480,17 +480,13 @@ object ManagerConfig {
    * Create ManagerConfig from command line and map of environment variables.
    *
    * @param args command line parameters
-   * @param env map of environment variables, which defaults to the actual
-   *        environment variables in scala.sys.env
-   * @return a Try containing a ManagerArgs instance (on success) or a Failure
-   *         in the case something went wrong. The Failure will contain an
-   *         ArgotUsageException if the command line parsing failed or the
-   *         -h or --help options were supplied.
+   * @param env environment variables; defaults to the actual environment from scala.sys.env
+   * @return a ManagerArgs instance
+   * @throws org.clapper.argot.ArgotUsageException if the command line parsing failed or if called
+   *         with the -h or --help options.
    */
-  def fromCommandLine(
-    args: Array[String],
-    env: Map[String, String] = scala.sys.env
-  ): ManagerConfig = {
+  def fromCommandLine(args: Array[String])
+                     (implicit env: Environment = Environment.sys): ManagerConfig = {
 
     val opts = (new Command("labrad", "The labrad manager.") with Options).parse(args)
 

--- a/manager/src/test/scala/org/labrad/manager/ManagerConfigTest.scala
+++ b/manager/src/test/scala/org/labrad/manager/ManagerConfigTest.scala
@@ -3,17 +3,21 @@ package org.labrad.manager
 import java.io.File
 import java.net.URI
 import org.labrad.crypto.CertConfig
+import org.labrad.util.cli.Environment
 import org.scalatest.FunSuite
-import scala.util.{Failure, Success}
 
 class ManagerConfigTest extends FunSuite {
+
+  // If not otherwise specified, use empty environment for these tests.
+  implicit val defaultEnv = Environment()
 
   test("default manager config works with empty command line and env") {
     ManagerConfig.fromCommandLine(Array())
   }
 
   test("port can be set from environment variable") {
-    val config = ManagerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "7777"))
+    val env = Environment("LABRADPORT" -> "7777")
+    val config = ManagerConfig.fromCommandLine(Array())(env)
     assert(config.port == 7777)
   }
 
@@ -26,15 +30,15 @@ class ManagerConfigTest extends FunSuite {
   }
 
   test("port command line arg overrides environment variable") {
-    val config = ManagerConfig.fromCommandLine(
-      Array("--port=1234"),
-      env = Map("LABRADPORT" -> "2345"))
+    val env = Environment("LABRADPORT" -> "2345")
+    val config = ManagerConfig.fromCommandLine(Array("--port=1234"))(env)
     assert(config.port == 1234)
   }
 
   test("port env var must be an integer") {
+    val env = Environment("LABRADPORT" -> "foo")
     intercept[Exception] {
-      ManagerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "foo"))
+      ManagerConfig.fromCommandLine(Array())(env)
     }
   }
 
@@ -50,9 +54,8 @@ class ManagerConfigTest extends FunSuite {
   }
 
   test("password can be set from environment variable") {
-    val config = ManagerConfig.fromCommandLine(
-      Array(),
-      env = Map("LABRADPASSWORD" -> "foo"))
+    val env = Environment("LABRADPASSWORD" -> "foo")
+    val config = ManagerConfig.fromCommandLine(Array())(env)
     checkPassword(config, "foo")
   }
 
@@ -65,9 +68,8 @@ class ManagerConfigTest extends FunSuite {
   }
 
   test("password command line arg overrides environment variable") {
-    val config = ManagerConfig.fromCommandLine(
-      Array("--password=foo"),
-      env = Map("LABRADPASSWORD" -> "bar"))
+    val env = Environment("LABRADPASSWORD" -> "bar")
+    val config = ManagerConfig.fromCommandLine(Array("--password=foo"))(env)
     checkPassword(config, "foo")
   }
 
@@ -77,32 +79,29 @@ class ManagerConfigTest extends FunSuite {
   }
 
   test("registry can be set from environment variable") {
-    val config = ManagerConfig.fromCommandLine(
-      Array(),
-      env = Map("LABRADREGISTRY" -> "/var/labrad/registry/"))
+    val env = Environment("LABRADREGISTRY" -> "/var/labrad/registry/")
+    val config = ManagerConfig.fromCommandLine(Array())(env)
     checkRegistry(config, "/var/labrad/registry/")
   }
 
   test("registry can be set from command line") {
-    val config1 = ManagerConfig.fromCommandLine(
-      Array("--registry", "/var/labrad/registry/"))
+    val config1 = ManagerConfig.fromCommandLine(Array("--registry", "/var/labrad/registry/"))
     checkRegistry(config1, "/var/labrad/registry/")
 
-    val config2 = ManagerConfig.fromCommandLine(
-      Array("--registry=/var/labrad/registry/"))
+    val config2 = ManagerConfig.fromCommandLine(Array("--registry=/var/labrad/registry/"))
     checkRegistry(config2, "/var/labrad/registry/")
   }
 
   test("registry command line arg overrides environment variable") {
-    val config = ManagerConfig.fromCommandLine(
-      Array("--registry=/var/labrad/registry/for-real/"),
-      env = Map("LABRADREGISTRY" -> "/var/labrad/registry/not-this-time"))
-    checkRegistry(config, "/var/labrad/registry/for-real/")
+    val env = Environment("LABRADREGISTRY" -> "/var/labrad/fake-reg")
+    val config = ManagerConfig.fromCommandLine(Array("--registry=/var/labrad/real-reg/"))(env)
+    checkRegistry(config, "/var/labrad/real-reg/")
   }
 
 
   test("tls-port can be set from environment variable") {
-    val config = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "7777"))
+    val env = Environment("LABRAD_TLS_PORT" -> "7777")
+    val config = ManagerConfig.fromCommandLine(Array())(env)
     assert(config.tlsPort == 7777)
   }
 
@@ -115,15 +114,15 @@ class ManagerConfigTest extends FunSuite {
   }
 
   test("tls-port command line arg overrides environment variable") {
-    val config = ManagerConfig.fromCommandLine(
-      Array("--tls-port=1234"),
-      env = Map("LABRAD_TLS_PORT" -> "2345"))
+    val env = Environment("LABRAD_TLS_PORT" -> "2345")
+    val config = ManagerConfig.fromCommandLine(Array("--tls-port=1234"))(env)
     assert(config.tlsPort == 1234)
   }
 
   test("tls-port env var must be an integer") {
+    val env = Environment("LABRAD_TLS_PORT" -> "foo")
     intercept[Exception] {
-      ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "foo"))
+      ManagerConfig.fromCommandLine(Array())(env)
     }
   }
 
@@ -135,7 +134,8 @@ class ManagerConfigTest extends FunSuite {
 
 
   test("tls-required can be set from environment variable") {
-    val config = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_REQUIRED" -> "no"))
+    val env = Environment("LABRAD_TLS_REQUIRED" -> "no")
+    val config = ManagerConfig.fromCommandLine(Array())(env)
     assert(config.tlsRequired == false)
   }
 
@@ -148,15 +148,15 @@ class ManagerConfigTest extends FunSuite {
   }
 
   test("tls-required command line arg overrides environment variable") {
-    val config = ManagerConfig.fromCommandLine(
-      Array("--tls-required=no"),
-      env = Map("LABRAD_TLS_REQUIRED" -> "yes"))
+    val env = Environment("LABRAD_TLS_REQUIRED" -> "yes")
+    val config = ManagerConfig.fromCommandLine(Array("--tls-required=no"))(env)
     assert(config.tlsRequired == false)
   }
 
   test("tls-required env var must be a valid option") {
+    val env = Environment("LABRAD_TLS_REQUIRED" -> "foo")
     intercept[Exception] {
-      ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_REQUIRED" -> "foo"))
+      ManagerConfig.fromCommandLine(Array())(env)
     }
   }
 
@@ -168,7 +168,8 @@ class ManagerConfigTest extends FunSuite {
 
 
   test("tls-hosts can be set from environment variable") {
-    val config = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_HOSTS" -> "foo.com"))
+    val env = Environment("LABRAD_TLS_HOSTS" -> "foo.com")
+    val config = ManagerConfig.fromCommandLine(Array())(env)
     assert(config.tlsHosts == Map("foo.com" -> CertConfig.SelfSigned))
   }
 
@@ -181,9 +182,8 @@ class ManagerConfigTest extends FunSuite {
   }
 
   test("tls-hosts command line arg overrides environment variable") {
-    val config = ManagerConfig.fromCommandLine(
-      Array("--tls-hosts=foo.com"),
-      env = Map("LABRAD_TLS_HOSTS" -> "bar.com"))
+    val env = Environment("LABRAD_TLS_HOSTS" -> "bar.com")
+    val config = ManagerConfig.fromCommandLine(Array("--tls-hosts=foo.com"))(env)
     assert(config.tlsHosts == Map("foo.com" -> CertConfig.SelfSigned))
   }
 

--- a/manager/src/test/scala/org/labrad/manager/ManagerConfigTest.scala
+++ b/manager/src/test/scala/org/labrad/manager/ManagerConfigTest.scala
@@ -9,38 +9,39 @@ import scala.util.{Failure, Success}
 class ManagerConfigTest extends FunSuite {
 
   test("default manager config works with empty command line and env") {
-    val tryConfig = ManagerConfig.fromCommandLine(Array())
-    assert(tryConfig.isInstanceOf[Success[_]])
+    ManagerConfig.fromCommandLine(Array())
   }
 
   test("port can be set from environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "7777"))
+    val config = ManagerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "7777"))
     assert(config.port == 7777)
   }
 
   test("port can be set from command line") {
-    val Success(config1) = ManagerConfig.fromCommandLine(Array("--port", "7777"))
+    val config1 = ManagerConfig.fromCommandLine(Array("--port", "7777"))
     assert(config1.port == 7777)
 
-    val Success(config2) = ManagerConfig.fromCommandLine(Array("--port=7878"))
+    val config2 = ManagerConfig.fromCommandLine(Array("--port=7878"))
     assert(config2.port == 7878)
   }
 
   test("port command line arg overrides environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(
+    val config = ManagerConfig.fromCommandLine(
       Array("--port=1234"),
       env = Map("LABRADPORT" -> "2345"))
     assert(config.port == 1234)
   }
 
   test("port env var must be an integer") {
-    val tryConfig = ManagerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ManagerConfig.fromCommandLine(Array(), env = Map("LABRADPORT" -> "foo"))
+    }
   }
 
   test("port command line must be an integer") {
-    val tryConfig = ManagerConfig.fromCommandLine(Array("--port=foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ManagerConfig.fromCommandLine(Array("--port=foo"))
+    }
   }
 
 
@@ -49,22 +50,22 @@ class ManagerConfigTest extends FunSuite {
   }
 
   test("password can be set from environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(
+    val config = ManagerConfig.fromCommandLine(
       Array(),
       env = Map("LABRADPASSWORD" -> "foo"))
     checkPassword(config, "foo")
   }
 
   test("password can be set from command line") {
-    val Success(config1) = ManagerConfig.fromCommandLine(Array("--password", "foo"))
+    val config1 = ManagerConfig.fromCommandLine(Array("--password", "foo"))
     checkPassword(config1, "foo")
 
-    val Success(config2) = ManagerConfig.fromCommandLine(Array("--password=foo"))
+    val config2 = ManagerConfig.fromCommandLine(Array("--password=foo"))
     checkPassword(config2, "foo")
   }
 
   test("password command line arg overrides environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(
+    val config = ManagerConfig.fromCommandLine(
       Array("--password=foo"),
       env = Map("LABRADPASSWORD" -> "bar"))
     checkPassword(config, "foo")
@@ -76,24 +77,24 @@ class ManagerConfigTest extends FunSuite {
   }
 
   test("registry can be set from environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(
+    val config = ManagerConfig.fromCommandLine(
       Array(),
       env = Map("LABRADREGISTRY" -> "/var/labrad/registry/"))
     checkRegistry(config, "/var/labrad/registry/")
   }
 
   test("registry can be set from command line") {
-    val Success(config1) = ManagerConfig.fromCommandLine(
+    val config1 = ManagerConfig.fromCommandLine(
       Array("--registry", "/var/labrad/registry/"))
     checkRegistry(config1, "/var/labrad/registry/")
 
-    val Success(config2) = ManagerConfig.fromCommandLine(
+    val config2 = ManagerConfig.fromCommandLine(
       Array("--registry=/var/labrad/registry/"))
     checkRegistry(config2, "/var/labrad/registry/")
   }
 
   test("registry command line arg overrides environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(
+    val config = ManagerConfig.fromCommandLine(
       Array("--registry=/var/labrad/registry/for-real/"),
       env = Map("LABRADREGISTRY" -> "/var/labrad/registry/not-this-time"))
     checkRegistry(config, "/var/labrad/registry/for-real/")
@@ -101,96 +102,100 @@ class ManagerConfigTest extends FunSuite {
 
 
   test("tls-port can be set from environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "7777"))
+    val config = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "7777"))
     assert(config.tlsPort == 7777)
   }
 
   test("tls-port can be set from command line") {
-    val Success(config1) = ManagerConfig.fromCommandLine(Array("--tls-port", "7777"))
+    val config1 = ManagerConfig.fromCommandLine(Array("--tls-port", "7777"))
     assert(config1.tlsPort == 7777)
 
-    val Success(config2) = ManagerConfig.fromCommandLine(Array("--tls-port=7878"))
+    val config2 = ManagerConfig.fromCommandLine(Array("--tls-port=7878"))
     assert(config2.tlsPort == 7878)
   }
 
   test("tls-port command line arg overrides environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(
+    val config = ManagerConfig.fromCommandLine(
       Array("--tls-port=1234"),
       env = Map("LABRAD_TLS_PORT" -> "2345"))
     assert(config.tlsPort == 1234)
   }
 
   test("tls-port env var must be an integer") {
-    val tryConfig = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_PORT" -> "foo"))
+    }
   }
 
   test("tls-port command line must be an integer") {
-    val tryConfig = ManagerConfig.fromCommandLine(Array("--tls-port=foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ManagerConfig.fromCommandLine(Array("--tls-port=foo"))
+    }
   }
 
 
   test("tls-required can be set from environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_REQUIRED" -> "no"))
+    val config = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_REQUIRED" -> "no"))
     assert(config.tlsRequired == false)
   }
 
   test("tls-required can be set from command line") {
-    val Success(config1) = ManagerConfig.fromCommandLine(Array("--tls-required", "no"))
+    val config1 = ManagerConfig.fromCommandLine(Array("--tls-required", "no"))
     assert(config1.tlsRequired == false)
 
-    val Success(config2) = ManagerConfig.fromCommandLine(Array("--tls-required=no"))
+    val config2 = ManagerConfig.fromCommandLine(Array("--tls-required=no"))
     assert(config2.tlsRequired == false)
   }
 
   test("tls-required command line arg overrides environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(
+    val config = ManagerConfig.fromCommandLine(
       Array("--tls-required=no"),
       env = Map("LABRAD_TLS_REQUIRED" -> "yes"))
     assert(config.tlsRequired == false)
   }
 
   test("tls-required env var must be a valid option") {
-    val tryConfig = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_REQUIRED" -> "foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_REQUIRED" -> "foo"))
+    }
   }
 
   test("tls-required command line must be a valid option") {
-    val tryConfig = ManagerConfig.fromCommandLine(Array("--tls-required=foo"))
-    assert(tryConfig.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ManagerConfig.fromCommandLine(Array("--tls-required=foo"))
+    }
   }
 
 
   test("tls-hosts can be set from environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_HOSTS" -> "foo.com"))
+    val config = ManagerConfig.fromCommandLine(Array(), env = Map("LABRAD_TLS_HOSTS" -> "foo.com"))
     assert(config.tlsHosts == Map("foo.com" -> CertConfig.SelfSigned))
   }
 
   test("tls-hosts can be set from command line") {
-    val Success(config1) = ManagerConfig.fromCommandLine(Array("--tls-hosts", "foo.com"))
+    val config1 = ManagerConfig.fromCommandLine(Array("--tls-hosts", "foo.com"))
     assert(config1.tlsHosts == Map("foo.com" -> CertConfig.SelfSigned))
 
-    val Success(config2) = ManagerConfig.fromCommandLine(Array("--tls-hosts=foo.com"))
+    val config2 = ManagerConfig.fromCommandLine(Array("--tls-hosts=foo.com"))
     assert(config2.tlsHosts == Map("foo.com" -> CertConfig.SelfSigned))
   }
 
   test("tls-hosts command line arg overrides environment variable") {
-    val Success(config) = ManagerConfig.fromCommandLine(
+    val config = ManagerConfig.fromCommandLine(
       Array("--tls-hosts=foo.com"),
       env = Map("LABRAD_TLS_HOSTS" -> "bar.com"))
     assert(config.tlsHosts == Map("foo.com" -> CertConfig.SelfSigned))
   }
 
   test("tls-hosts may contain cert and key files") {
-    val Success(config1) = ManagerConfig.fromCommandLine(Array(
+    val config1 = ManagerConfig.fromCommandLine(Array(
       "--tls-hosts=foo.com?cert=/my/cert/file.crt&key=/my/key/file.pem"))
     assert(config1.tlsHosts == Map(
       "foo.com" -> CertConfig.Files(
         cert = new File("/my/cert/file.crt"),
         key = new File("/my/key/file.pem"))))
 
-    val Success(config2) = ManagerConfig.fromCommandLine(Array(
+    val config2 = ManagerConfig.fromCommandLine(Array(
       "--tls-hosts=foo.com?cert=/my/cert/file.crt&key=/my/key/file.pem&intermediates=/my/interm/file.pem"))
     assert(config2.tlsHosts == Map(
       "foo.com" -> CertConfig.Files(
@@ -200,15 +205,17 @@ class ManagerConfigTest extends FunSuite {
   }
 
   test("tls-hosts must provide cert and key if either is provided") {
-    val tryConfig1 = ManagerConfig.fromCommandLine(Array("--tls-hosts=foo.com?cert=/my/cert/file.crt"))
-    assert(tryConfig1.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ManagerConfig.fromCommandLine(Array("--tls-hosts=foo.com?cert=/my/cert/file.crt"))
+    }
 
-    val tryConfig2 = ManagerConfig.fromCommandLine(Array("--tls-hosts=foo.com?key=/my/key/file.pem"))
-    assert(tryConfig2.isInstanceOf[Failure[_]])
+    intercept[Exception] {
+      ManagerConfig.fromCommandLine(Array("--tls-hosts=foo.com?key=/my/key/file.pem"))
+    }
   }
 
   test("tls-hosts may contain multiple semicolon-separated hosts") {
-    val Success(config) = ManagerConfig.fromCommandLine(Array(
+    val config = ManagerConfig.fromCommandLine(Array(
       "--tls-hosts=private1;public.com?cert=/my/cert/file.crt&key=/my/key/file.pem;private2"))
     assert(config.tlsHosts == Map(
       "private1" -> CertConfig.SelfSigned,


### PR DESCRIPTION
Previously we defined command line options as local variables in methods like `ServerConfig.fromCommandLine`. While this works, it makes it hard to reuse command line arguments. Here we introduce a `Command` class that contains a command line parser and lets us mix in additional options defined in traits. We can then combine command line args from multiple traits and also define separate methods that take a particular trait type and pull out the values from that type.
