### PR TITLE
Optimize construction and extraction of array data

### DIFF
--- a/core/src/main/scala/org/labrad/data/Bytes.scala
+++ b/core/src/main/scala/org/labrad/data/Bytes.scala
@@ -18,6 +18,27 @@ object EndianAwareByteArray {
     def setLong(ofs: Int, data: Long)(implicit bo: ByteOrder) = ByteManip.setLong(buf, ofs, data)
     def setDouble(ofs: Int, data: Double)(implicit bo: ByteOrder) = ByteManip.setDouble(buf, ofs, data)
   }
+
+  /**
+   * Provides a view onto an existing byte array with a certain offset.
+   *
+   * This allows us to get and set multi-byte values into the underlying array with the specified
+   * endianness.
+   */
+  case class EndianAwareByteSlice(buf: Array[Byte], ofs: Int, length: Int)
+                                 (implicit byteOrder: ByteOrder) {
+    def getBool(ofs: Int): Boolean = ByteManip.getBool(buf, ofs + this.ofs)
+    def getInt(ofs: Int): Int = ByteManip.getInt(buf, ofs + this.ofs)
+    def getUInt(ofs: Int): Long = ByteManip.getUInt(buf, ofs + this.ofs)
+    def getLong(ofs: Int): Long = ByteManip.getLong(buf, ofs + this.ofs)
+    def getDouble(ofs: Int): Double = ByteManip.getDouble(buf, ofs + this.ofs)
+
+    def setBool(ofs: Int, data: Boolean) = ByteManip.setBool(buf, ofs + this.ofs, data)
+    def setInt(ofs: Int, data: Int) = ByteManip.setInt(buf, ofs + this.ofs, data)
+    def setUInt(ofs: Int, data: Long) = ByteManip.setUInt(buf, ofs + this.ofs, data)
+    def setLong(ofs: Int, data: Long) = ByteManip.setLong(buf, ofs + this.ofs, data)
+    def setDouble(ofs: Int, data: Double) = ByteManip.setDouble(buf, ofs + this.ofs, data)
+  }
 }
 
 /** Functions for converting basic data types to/from arrays of bytes */

--- a/core/src/main/scala/org/labrad/data/Getter.scala
+++ b/core/src/main/scala/org/labrad/data/Getter.scala
@@ -38,6 +38,79 @@ object Getter {
     def get(data: Data): Complex = data.getComplex
   }
 
+  implicit val boolArrayGetter: Getter[Array[Boolean]] = new Getter[Array[Boolean]] {
+    val t = TArr(TBool)
+    val elemWidth = t.elem.dataWidth
+
+    def get(data: Data): Array[Boolean] = {
+      require(data.t == t, s"invalid type: expected ${t}, got ${data.t}")
+      val bytes = data.arrayBytes
+      val n = data.arraySize
+      val result = Array.ofDim[Boolean](n)
+      var i = 0
+      while (i < n) {
+        result(i) = bytes.getBool(elemWidth * i)
+        i += 1
+      }
+      result
+    }
+  }
+
+  implicit val intArrayGetter: Getter[Array[Int]] = new Getter[Array[Int]] {
+    val t = TArr(TInt)
+    val elemWidth = t.elem.dataWidth
+
+    def get(data: Data): Array[Int] = {
+      require(data.t == t, s"invalid type: expected ${t}, got ${data.t}")
+      val bytes = data.arrayBytes
+      val n = data.arraySize
+      val result = Array.ofDim[Int](n)
+      var i = 0
+      while (i < n) {
+        result(i) = bytes.getInt(elemWidth * i)
+        i += 1
+      }
+      result
+    }
+  }
+
+  implicit val uintArrayGetter: Getter[Array[Long]] = new Getter[Array[Long]] {
+    val t = TArr(TUInt)
+    val elemWidth = t.elem.dataWidth
+
+    def get(data: Data): Array[Long] = {
+      require(data.t == t, s"invalid type: expected ${t}, got ${data.t}")
+      val bytes = data.arrayBytes
+      val n = data.arraySize
+      val result = Array.ofDim[Long](n)
+      var i = 0
+      while (i < n) {
+        result(i) = bytes.getUInt(elemWidth * i)
+        i += 1
+      }
+      result
+    }
+  }
+
+  implicit val doubleArrayGetter: Getter[Array[Double]] = new Getter[Array[Double]] {
+    val t = TArr(TValue())
+    val elemWidth = t.elem.dataWidth
+
+    def get(data: Data): Array[Double] = {
+      require(data.t == t, s"invalid type: expected ${t}, got ${data.t}")
+      val bytes = data.arrayBytes
+      val n = data.arraySize
+      assert(bytes.length == elemWidth * n)
+      val result = Array.ofDim[Double](n)
+      var i = 0
+      while (i < n) {
+        result(i) = bytes.getDouble(elemWidth * i)
+        i += 1
+      }
+      result
+    }
+  }
+
   implicit def arrayGetter[T](implicit elemGetter: Getter[T], elemTag: ClassTag[T]): Getter[Array[T]] = new Getter[Array[T]] {
     def get(data: Data): Array[T] = {
       data.flatIterator.map(elemGetter.get).toArray

--- a/core/src/test/scala/org/labrad/data/DataBench.scala
+++ b/core/src/test/scala/org/labrad/data/DataBench.scala
@@ -1,20 +1,76 @@
 package org.labrad.data
 
 import io.netty.buffer.{ByteBuf, Unpooled}
+import java.nio.ByteOrder
 import java.nio.ByteOrder._
 
 object DataBench {
 
-  def timeIt[A](msg: String, noisy: Boolean = true)(f: => A): (A, Long) = {
+  def timeIt[A](msg: String, noisy: Boolean = true, reps: Int = 1000)(f: => A): (A, Long) = {
     for (i <- 0 until 10) { f }
     val start = System.nanoTime()
     val result = f
+    for (_ <- 0 until reps-1) {
+      f
+    }
     val end = System.nanoTime()
     val elapsed = end - start
     if (noisy) {
-      println(s"$msg: elapsed = ${elapsed/1.0e9} ms")
+      println(s"$msg: elapsed = ${elapsed / 1.0e3 / reps} us")
     }
     (result, elapsed)
+  }
+
+  def bench(data: Data): Unit = {
+    val bytesBE = data.toBytes(BIG_ENDIAN)
+    val bytesLE = data.toBytes(LITTLE_ENDIAN)
+
+    val unflatBE = TreeData.fromBytes(data.t, bytesBE)(BIG_ENDIAN)
+    val unflatLE = TreeData.fromBytes(data.t, bytesLE)(LITTLE_ENDIAN)
+
+    val flatBE = FlatData.fromBytes(data.t, bytesBE)(BIG_ENDIAN)
+    val flatLE = FlatData.fromBytes(data.t, bytesLE)(LITTLE_ENDIAN)
+
+    timeIt("flatten") { unflatBE.toBytes(BIG_ENDIAN) }
+    timeIt("flattenFlat") { flatBE.toBytes(BIG_ENDIAN) }
+    println()
+
+    timeIt("flattenSwap") { unflatBE.toBytes(LITTLE_ENDIAN) }
+    timeIt("flattenFlatSwap") { flatBE.toBytes(BIG_ENDIAN) }
+    println()
+
+    timeIt("unflattenBE") { TreeData.fromBytes(data.t, bytesBE)(BIG_ENDIAN) }
+    timeIt("unflattenFlatBE") { FlatData.fromBytes(data.t, bytesBE)(BIG_ENDIAN) }
+    println()
+
+    timeIt("unflattenLE") { TreeData.fromBytes(data.t, bytesLE)(LITTLE_ENDIAN) }
+    timeIt("unflattenFlatLE") { FlatData.fromBytes(data.t, bytesLE)(LITTLE_ENDIAN) }
+    println()
+  }
+
+  def benchGet[A](msg: String, data: Data, get: Data => A): Unit = {
+    val bytesBE = data.toBytes(BIG_ENDIAN)
+    val bytesLE = data.toBytes(LITTLE_ENDIAN)
+
+    val treeBE = TreeData.fromBytes(data.t, bytesBE)(BIG_ENDIAN)
+    val treeLE = TreeData.fromBytes(data.t, bytesLE)(LITTLE_ENDIAN)
+
+    val flatBE = FlatData.fromBytes(data.t, bytesBE)(BIG_ENDIAN)
+    val flatLE = FlatData.fromBytes(data.t, bytesLE)(LITTLE_ENDIAN)
+
+    timeIt(s"${msg}:getBE", reps = 100) { get(treeBE) }
+    timeIt(s"${msg}:getFlatBE", reps = 100) { get(flatBE) }
+    println()
+
+    timeIt(s"${msg}:getLE", reps = 100) { get(treeLE) }
+    timeIt(s"${msg}:getFlatLE", reps = 100) { get(flatLE) }
+    println()
+  }
+
+  def benchSet(msg: String, set: ByteOrder => Data): Unit = {
+    timeIt(s"${msg}:BE", reps = 100) { set(BIG_ENDIAN) }
+    timeIt(s"${msg}:LE", reps = 100) { set(LITTLE_ENDIAN) }
+    println()
   }
 
   def main(args: Array[String]): Unit = {
@@ -34,67 +90,95 @@ object DataBench {
       b.result()
     }
 
-    val data2 = Arr(Seq.fill(N) { Cluster(Str("01:23:45:67:89:AB"), Str("01:23:45:67:89:AB"), Integer(128), Bytes(Array.tabulate(128)(_.toByte))) })
+    val data2 = Arr(Seq.fill(N) {
+      Cluster(
+        Str("01:23:45:67:89:AB"),
+        Str("01:23:45:67:89:AB"),
+        Integer(128),
+        Bytes(Array.tabulate(128)(_.toByte)))
+      }
+    )
 
     assert(data1 == data2)
     assert(data1.toBytes(BIG_ENDIAN).toSeq == data2.toBytes(BIG_ENDIAN).toSeq)
 
-    val data = data2
+    val intArray = Array.tabulate[Int](100000) { i => i }
+    val intArrayData = Arr(intArray)
+    val doubleArray = Array.tabulate[Double](100000) { i => i.toDouble }
+    val doubleArrayData = Arr(doubleArray)
 
-    val bytesBE = data1.toBytes(BIG_ENDIAN)
-    val bytesLE = data1.toBytes(LITTLE_ENDIAN)
-
-    val unflatBE = TreeData.fromBytes(data.t, bytesBE)(BIG_ENDIAN)
-    val unflatLE = TreeData.fromBytes(data.t, bytesLE)(LITTLE_ENDIAN)
-
-    val flatBE = FlatData.fromBytes(data.t, bytesBE)(BIG_ENDIAN)
-    val flatLE = FlatData.fromBytes(data.t, bytesLE)(LITTLE_ENDIAN)
-
-    timeIt("flatten") {
-      for (i <- 0 until 1000) {
-        unflatBE.toBytes(BIG_ENDIAN)
-      }
-    }
-    timeIt("flattenFlat") {
-      for (i <- 0 until 1000) {
-        flatBE.toBytes(BIG_ENDIAN)
-      }
-    }
+    println("cluster array:")
+    bench(data1)
     println()
 
-    timeIt("flattenSwap") {
-      for (i <- 0 until 1000) {
-        unflatBE.toBytes(LITTLE_ENDIAN)
+    println("int array:")
+    bench(intArrayData)
+    benchGet("getFlatIter", intArrayData, data => {
+      data.flatIterator.map(_.get[Int]).toArray
+    })
+    benchGet("getFast", intArrayData, data => {
+      val bytes = data.arrayBytes
+      val n = data.arraySize
+      assert(bytes.length == 4*n)
+      val result = Array.ofDim[Int](n)
+      var i = 0
+      while (i < n) {
+        result(i) = bytes.getInt(4*i)
+        i += 1
       }
-    }
-    timeIt("flattenFlatSwap") {
-      for (i <- 0 until 1000) {
-        flatBE.toBytes(BIG_ENDIAN)
+      result
+    })
+    benchGet("get[Array[Int]]", intArrayData, _.get[Array[Int]])
+    benchSet("set:Arr(ints)", implicit endianness => {
+      Arr(intArray)
+    })
+    benchSet("set:fast", implicit endianness => {
+      val data = Data("*i")
+      val n = intArray.length
+      data.setArrayShape(n)
+      val bytes = data.arrayBytes
+      var i = 0
+      while (i < n) {
+        bytes.setInt(4 * i, intArray(i))
+        i += 1
       }
-    }
+      data
+    })
     println()
 
-    timeIt("unflattenBE") {
-      for (i <- 0 until 1000) {
-        TreeData.fromBytes(data.t, bytesBE)(BIG_ENDIAN)
+    println("double array:")
+    bench(doubleArrayData)
+    benchGet("getFlatIter", doubleArrayData, data => {
+      data.flatIterator.map(_.get[Double]).toArray
+    })
+    benchGet("getFast", doubleArrayData, data => {
+      val bytes = data.arrayBytes
+      val n = data.arraySize
+      assert(bytes.length == 8*n)
+      val result = Array.ofDim[Double](n)
+      var i = 0
+      while (i < n) {
+        result(i) = bytes.getDouble(8*i)
+        i += 1
       }
-    }
-    timeIt("unflattenFlatBE") {
-      for (i <- 0 until 1000) {
-        FlatData.fromBytes(data.t, bytesBE)(BIG_ENDIAN)
+      result
+    })
+    benchGet("get[Array[Double]]", doubleArrayData, _.get[Array[Double]])
+    benchSet("Arr(doubles)", implicit endianness => {
+      Arr(doubleArray)
+    })
+    benchSet("set:fast", implicit endianness => {
+      val data = Data("*v")
+      val n = doubleArray.length
+      data.setArrayShape(n)
+      val bytes = data.arrayBytes
+      var i = 0
+      while (i < n) {
+        bytes.setDouble(8 * i, doubleArray(i))
+        i += 1
       }
-    }
+      data
+    })
     println()
-
-    timeIt("unflattenLE") {
-      for (i <- 0 until 1000) {
-        TreeData.fromBytes(data.t, bytesLE)(LITTLE_ENDIAN)
-      }
-    }
-    timeIt("unflattenFlatLE") {
-      for (i <- 0 until 1000) {
-        FlatData.fromBytes(data.t, bytesLE)(LITTLE_ENDIAN)
-      }
-    }
   }
 }


### PR DESCRIPTION
We introduce a new `arrayBytes` method on Data objects that returns a view of the underlying bytes of the array. We then use this to implement optimized getters and constructors of arrays of primitive fixed-width types such as int and double. Benchmarks indicate that the getters (converting from data to `Array[Int]` or `Array[Double]`) are about 10x faster, while constructors (building Data of type "*i" or "*v" from scala Arrays) are about 5x faster. In addition, because the `arrayBytes` method is public, applications can implement their own optimized routines for other cases, though of course care must be taken to handle the raw bytes correctly.