### PR TITLE
Allow the auth server to check global password

### DIFF
--- a/manager/src/main/scala/org/labrad/manager/Manager.scala
+++ b/manager/src/main/scala/org/labrad/manager/Manager.scala
@@ -229,7 +229,7 @@ object Manager extends Logging {
     }
 
     val authStoreOpt = if (config.authServer) {
-      Some(AuthStore(file = config.authUsersFile))
+      Some(AuthStore(file = config.authUsersFile, globalPassword = config.password))
     } else {
       None
     }

--- a/manager/src/main/scala/org/labrad/manager/auth/AuthServer.scala
+++ b/manager/src/main/scala/org/labrad/manager/auth/AuthServer.scala
@@ -121,7 +121,12 @@ class AuthServer(
       case "username+password" =>
         val (username, password) = credentials.get[(String, String)]
         if (!auth.checkUserPassword(username, password)) {
-          sys.error("invalid username or password")
+          val message = if (username.isEmpty) {
+            "invalid password"
+          } else {
+            "invalid username or password"
+          }
+          sys.error(message)
         }
         username
 

--- a/manager/src/test/scala/org/labrad/manager/auth/AuthStoreTest.scala
+++ b/manager/src/test/scala/org/labrad/manager/auth/AuthStoreTest.scala
@@ -6,13 +6,14 @@ import org.scalatest.fixture.FunSuite
 
 class AuthStoreTest extends FunSuite {
 
-  case class Fixture(store: AuthStore)
+  case class Fixture(store: AuthStore, globalPassword: String)
   type FixtureParam = Fixture
 
   def withFixture(test: OneArgTest) = {
     Files.withTempFile { file =>
-      val authStore = AuthStore(file)
-      withFixture(test.toNoArgTest(Fixture(authStore)))
+      val globalPassword = "VerySecurePassword"
+      val authStore = AuthStore(file, globalPassword.toCharArray)
+      withFixture(test.toNoArgTest(Fixture(authStore, globalPassword)))
     }
   }
 
@@ -68,6 +69,10 @@ class AuthStoreTest extends FunSuite {
     intercept[Exception] {
       fix.store.checkUserPassword("user", "abc")
     }
+  }
+
+  test("checkUserPassword works for global user and password") { fix =>
+    assert(fix.store.checkUserPassword("", fix.globalPassword))
   }
 
   test("removeUser") { fix =>


### PR DESCRIPTION
This allows checking the global password through the auth server's `authenticate` method.